### PR TITLE
feat/packages(#13): 텍스트 컴포넌트 추가

### DIFF
--- a/packages/design-system/src/color.ts
+++ b/packages/design-system/src/color.ts
@@ -34,6 +34,7 @@ const color = {
   pointGreen: '#74D266',
   pointRed: '#FB4A4A',
   pointOrange: '#FF662A',
+  pointBlue: '#3E8BE3',
 };
 
 export default color;

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -6,3 +6,4 @@ export { default as Calender } from './src/Calender/Calender';
 export { default as Dropdown } from './src/Dropdown/Dropdown';
 export { default as Row } from './src/Flex/Row';
 export { default as Column } from './src/Flex/Column';
+export { default as Text } from './src/Text/Text';

--- a/packages/ui/src/Text/Text.tsx
+++ b/packages/ui/src/Text/Text.tsx
@@ -1,6 +1,5 @@
 import { font } from '@merried/design-system';
 import type { CSSProperties, HTMLAttributes, ReactNode } from 'react';
-import React from 'react';
 import styled, { css } from 'styled-components';
 
 type Font = keyof typeof font;

--- a/packages/ui/src/Text/Text.tsx
+++ b/packages/ui/src/Text/Text.tsx
@@ -1,0 +1,54 @@
+import { font } from '@merried/design-system';
+import type { CSSProperties, HTMLAttributes, ReactNode } from 'react';
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+type Font = keyof typeof font;
+
+interface TextProps extends HTMLAttributes<HTMLSpanElement> {
+  children: ReactNode;
+  color?: CSSProperties['color'];
+  fontType?: Font;
+  width?: CSSProperties['width'];
+  textAlign?: CSSProperties['textAlign'];
+  ellipsis?: boolean;
+  whiteSpace?: CSSProperties['whiteSpace'];
+  tag?: 'span' | 'p';
+}
+
+const Text = ({
+  children,
+  color,
+  fontType = 'H1',
+  width = 'auto',
+  textAlign = 'left',
+  ellipsis = false,
+  whiteSpace = 'nowrap',
+  tag = 'span',
+}: TextProps) => {
+  return (
+    <StyledText
+      style={{ color, textAlign, width, whiteSpace }}
+      fontType={fontType}
+      as={tag}
+      ellipsis={ellipsis}
+    >
+      {children}
+    </StyledText>
+  );
+};
+
+export default Text;
+
+const StyledText = styled.span.withConfig({
+  shouldForwardProp: (prop) => !['fontType', 'ellipsis'].includes(prop),
+})<{ fontType: Font; ellipsis: boolean }>`
+  ${({ fontType }) => font[fontType]};
+  ${(props) =>
+    props.ellipsis &&
+    css`
+      display: inline-block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    `}
+`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,7 +222,7 @@ importers:
         version: 9.23.0
       styled-reset:
         specifier: ^4.4.7
-        version: 4.5.2(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 4.5.2(styled-components@6.1.17)
       typescript:
         specifier: 5.8.2
         version: 5.8.2


### PR DESCRIPTION
## 📄 Summary

> 텍스트 컴포넌트를 추가했습니다.

<br>

## 🔨 Tasks

- 텍스트 컴포넌트 추가

<br>

## 🙋🏻 More
<img width="566" alt="스크린샷 2025-04-29 오전 10 25 33" src="https://github.com/user-attachments/assets/4d69c004-10ce-4fb9-8300-80b43521fb5c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - 다양한 타이포그래피 및 스타일 속성을 지원하는 새로운 `Text` 컴포넌트가 추가되었습니다.
    - `Text` 컴포넌트는 색상, 정렬, 너비, 줄바꿈, 말줄임표 처리, HTML 태그 지정 등 다양한 옵션을 제공합니다.  
    - 이제 UI 패키지에서 `Text` 컴포넌트를 사용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->