### PR TITLE
feat(mobile): 참석자 관리 페이지 퍼블리싱

### DIFF
--- a/apps/mobile/src/app/manage/page.tsx
+++ b/apps/mobile/src/app/manage/page.tsx
@@ -1,14 +1,39 @@
 'use client';
 
+import AttendeeList from '@/components/manage/AttendeeList/AttendeeList';
 import AppLayout from '@/layouts/AppLayout';
 import { color } from '@merried/design-system';
+import { ActionButton, Column, Text } from '@merried/ui';
+import { flex } from '@merried/utils';
+import styled from 'styled-components';
 
 const Manage = () => {
   return (
-    <AppLayout footer backgroundColor={color.G20}>
-      참석자 관리 페이지
+    <AppLayout footer backgroundColor={color.G0}>
+      <StyledManage>
+        <Column gap={20}>
+          <Text fontType="H2" color={color.G900}>
+            참석자 관리
+          </Text>
+          <ActionButton icon="ADD_ICON" background={color.primary} onClick={() => {}}>
+            참석자 추가
+          </ActionButton>
+        </Column>
+        <AttendeeList />
+      </StyledManage>
     </AppLayout>
   );
 };
 
 export default Manage;
+
+const StyledManage = styled.div`
+  ${flex({
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+  })}
+  width: 100%;
+  gap: 24px;
+  padding: 71px 12px 115px;
+`;

--- a/apps/mobile/src/app/manage/page.tsx
+++ b/apps/mobile/src/app/manage/page.tsx
@@ -15,7 +15,7 @@ const Manage = () => {
           <Text fontType="H2" color={color.G900}>
             참석자 관리
           </Text>
-          <ActionButton icon="ADD_ICON" background={color.primary} onClick={() => {}}>
+          <ActionButton icon="ADD_ICON" onClick={() => {}}>
             참석자 추가
           </ActionButton>
         </Column>

--- a/apps/mobile/src/components/manage/AttendeeList/AttendeeList.tsx
+++ b/apps/mobile/src/components/manage/AttendeeList/AttendeeList.tsx
@@ -1,0 +1,162 @@
+import { flex } from '@merried/utils';
+import styled from 'styled-components';
+import SearchInput from '../SearchInput/SearchInput';
+import { Column, Text } from '@merried/ui';
+import ListHeader from './ListHeader/ListHeader';
+import { Side } from '@/types/manage/client';
+import ListItem from './ListItem/ListItem';
+import { color } from '@merried/design-system';
+import { useState } from 'react';
+
+export const listData: {
+  name: string;
+  side: Side;
+  count: number;
+  attend: boolean;
+  money: boolean;
+  meal: boolean;
+}[] = [
+  {
+    name: '홍길동',
+    side: 'GROOM',
+    count: 3,
+    attend: true,
+    money: true,
+    meal: false,
+  },
+  {
+    name: '홍이장군',
+    side: 'GROOM',
+    count: 3,
+    attend: true,
+    money: true,
+    meal: false,
+  },
+  {
+    name: '김영희',
+    side: 'BRIDE',
+    count: 2,
+    attend: true,
+    money: false,
+    meal: true,
+  },
+  {
+    name: '박철수',
+    side: 'GROOM',
+    count: 1,
+    attend: false,
+    money: false,
+    meal: false,
+  },
+  {
+    name: '이민호',
+    side: 'BRIDE',
+    count: 4,
+    attend: true,
+    money: true,
+    meal: true,
+  },
+  {
+    name: '최지우',
+    side: 'GROOM',
+    count: 2,
+    attend: false,
+    money: true,
+    meal: false,
+  },
+  {
+    name: '장보리',
+    side: 'BRIDE',
+    count: 5,
+    attend: true,
+    money: false,
+    meal: false,
+  },
+  {
+    name: '오세훈',
+    side: 'GROOM',
+    count: 1,
+    attend: false,
+    money: true,
+    meal: true,
+  },
+  {
+    name: '오세훈2',
+    side: 'GROOM',
+    count: 1,
+    attend: false,
+    money: true,
+    meal: true,
+  },
+];
+
+const AttendeeList = () => {
+  const [search, setSearch] = useState('');
+  const isEmpty = listData.length === 0;
+
+  const searchNameData = listData.filter((item) =>
+    item.name.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearch(e.target.value);
+  };
+
+  return (
+    <StyledAttendeeList>
+      <Column gap={24} width="100%">
+        <SearchInput placeholder="이름을 입력해주세요" onChange={handleInputChange} />
+        {!isEmpty && <ListHeader />}
+      </Column>
+      <ListContainer>
+        <ListContent>
+          {isEmpty ? (
+            <EmptyContainer>
+              <Text fontType="H3_140per" color={color.G900} textAlign="center">
+                아직 참석 여부를
+                <br />
+                밝힌 사람이 없습니다
+              </Text>
+            </EmptyContainer>
+          ) : (
+            searchNameData.map((attendee, index) => (
+              <ListItem key={`attendee-${index}`} {...attendee} />
+            ))
+          )}
+        </ListContent>
+      </ListContainer>
+    </StyledAttendeeList>
+  );
+};
+
+export default AttendeeList;
+
+const StyledAttendeeList = styled.div`
+  ${flex({ flexDirection: 'column', alignItems: 'center' })}
+  width: 100%;
+  gap: 10px;
+`;
+
+const ListContainer = styled.div`
+  width: 100%;
+  height: calc(100vh - 450px);
+  overflow-y: auto;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+const ListContent = styled.div`
+  ${flex({ flexDirection: 'column', alignItems: 'center' })}
+  width: 100%;
+  gap: 10px;
+`;
+
+const EmptyContainer = styled.div`
+  ${flex({ flexDirection: 'column', alignItems: 'center', justifyContent: 'center' })}
+  width: 100%;
+  margin-top: 40%;
+`;

--- a/apps/mobile/src/components/manage/AttendeeList/ListHeader/ListHeader.tsx
+++ b/apps/mobile/src/components/manage/AttendeeList/ListHeader/ListHeader.tsx
@@ -1,0 +1,36 @@
+import { color } from '@merried/design-system';
+import { Row, Text } from '@merried/ui';
+import { flex } from '@merried/utils';
+import styled from 'styled-components';
+
+const ListHeader = () => {
+  return (
+    <StyledListHeader>
+      <Text fontType="Button3" color={color.G80}>
+        이름
+      </Text>
+      <Row alignItems="center" gap={20}>
+        <Text fontType="Button3" color={color.G80}>
+          참석
+        </Text>
+        <Text fontType="Button3" color={color.G80}>
+          축의금
+        </Text>
+        <Text fontType="Button3" color={color.G80}>
+          식권
+        </Text>
+      </Row>
+    </StyledListHeader>
+  );
+};
+
+export default ListHeader;
+
+const StyledListHeader = styled.div`
+  ${flex({ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' })}
+  width: 100%;
+  height: 58px;
+  background-color: ${color.G10};
+  border-radius: 8px;
+  padding: 18px 16px;
+`;

--- a/apps/mobile/src/components/manage/AttendeeList/ListHeader/ListHeader.tsx
+++ b/apps/mobile/src/components/manage/AttendeeList/ListHeader/ListHeader.tsx
@@ -17,7 +17,7 @@ const ListHeader = () => {
           축의금
         </Text>
         <Text fontType="Button3" color={color.G80}>
-          식권
+          식사
         </Text>
       </Row>
     </StyledListHeader>

--- a/apps/mobile/src/components/manage/AttendeeList/ListItem/ListItem.tsx
+++ b/apps/mobile/src/components/manage/AttendeeList/ListItem/ListItem.tsx
@@ -1,5 +1,5 @@
+import { SIDE } from '@/constants/common/constant';
 import { Side } from '@/types/manage/client';
-import { formatSide } from '@/utils/formatSide';
 import { color } from '@merried/design-system';
 import { IconPencil } from '@merried/icon';
 import { Column, Row, Text } from '@merried/ui';
@@ -26,7 +26,7 @@ const ListItem = ({ name, side, count, attend, money, meal }: ListItemProps) => 
           </Text>
           <Row alignItems="center" gap={4}>
             <Text fontType="P3" color={color.G70}>
-              {formatSide[side]}측
+              {SIDE[side]}측
             </Text>
             <Text fontType="P3" color={color.G70}>
               •

--- a/apps/mobile/src/components/manage/AttendeeList/ListItem/ListItem.tsx
+++ b/apps/mobile/src/components/manage/AttendeeList/ListItem/ListItem.tsx
@@ -1,0 +1,65 @@
+import { Side } from '@/types/manage/client';
+import { formatSide } from '@/utils/formatSide';
+import { color } from '@merried/design-system';
+import { IconPencil } from '@merried/icon';
+import { Column, Row, Text } from '@merried/ui';
+import { flex } from '@merried/utils';
+import styled from 'styled-components';
+
+interface ListItemProps {
+  name: string;
+  side: Side;
+  count: number;
+  attend: boolean;
+  money: boolean;
+  meal: boolean;
+}
+
+const ListItem = ({ name, side, count, attend, money, meal }: ListItemProps) => {
+  return (
+    <StyledListItem onClick={() => {}}>
+      <Row alignItems="center" gap={10}>
+        <IconPencil width={16} height={16} />
+        <Column alignItems="flex-start">
+          <Text fontType="P3" color={color.G900}>
+            {name}
+          </Text>
+          <Row alignItems="center" gap={4}>
+            <Text fontType="P3" color={color.G70}>
+              {formatSide[side]}측
+            </Text>
+            <Text fontType="P3" color={color.G70}>
+              •
+            </Text>
+            <Text fontType="P3" color={color.G70}>
+              본인 포함 {count}명
+            </Text>
+          </Row>
+        </Column>
+      </Row>
+      <Row alignItems="center" justifyContent="space-between" width={127}>
+        <Text fontType="P3" color={color.G900} width={25} textAlign="center">
+          {attend === true ? 'O' : 'X'}
+        </Text>
+        <Text fontType="P3" color={color.G900} width={25} textAlign="center">
+          {money === true ? 'O' : 'X'}
+        </Text>
+        <Text fontType="P3" color={color.G900} width={25} textAlign="center">
+          {meal === true ? 'O' : 'X'}
+        </Text>
+      </Row>
+    </StyledListItem>
+  );
+};
+
+export default ListItem;
+
+const StyledListItem = styled.div`
+  ${flex({ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' })}
+  width: 100%;
+  height: 68px;
+  background-color: ${color.G0};
+  border: 1px solid ${color.G40};
+  border-radius: 8px;
+  padding: 18px 16px;
+`;

--- a/apps/mobile/src/components/manage/SearchInput/SearchInput.tsx
+++ b/apps/mobile/src/components/manage/SearchInput/SearchInput.tsx
@@ -25,6 +25,7 @@ const SearchInput = ({
   return (
     <StyledSearchInput onClick={handleClick} style={{ width }}>
       <Input
+        ref={inputRef}
         placeholder={placeholder}
         onChange={onChange}
         value={value}

--- a/apps/mobile/src/components/manage/SearchInput/SearchInput.tsx
+++ b/apps/mobile/src/components/manage/SearchInput/SearchInput.tsx
@@ -1,0 +1,64 @@
+import { color, font } from '@merried/design-system';
+import { IconSearch } from '@merried/icon';
+import { flex } from '@merried/utils';
+import { CSSProperties, InputHTMLAttributes, useRef } from 'react';
+import styled from 'styled-components';
+
+export interface SearchInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  width?: CSSProperties['width'];
+}
+
+const SearchInput = ({
+  width,
+  onChange,
+  value,
+  name,
+  placeholder,
+  type = 'text',
+}: SearchInputProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleClick = () => {
+    inputRef.current?.focus();
+  };
+
+  return (
+    <StyledSearchInput onClick={handleClick} style={{ width }}>
+      <Input
+        placeholder={placeholder}
+        onChange={onChange}
+        value={value}
+        name={name}
+        type={type}
+      />
+      <IconSearch width={16} height={16} />
+    </StyledSearchInput>
+  );
+};
+
+export default SearchInput;
+
+const StyledSearchInput = styled.div`
+  ${flex({ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' })}
+  width: 100%;
+  height: 44px;
+  border-radius: 8px;
+  background-color: ${color.G10};
+  padding: 14px 16px;
+`;
+
+const Input = styled.input`
+  width: 90%;
+  background-color: ${color.G10};
+  ${font.P3}
+
+  ::placeholder {
+    ${font.P3}
+    color: ${color.G60};
+  }
+
+  &::-webkit-input-placeholder {
+    ${font.P3}
+    color: ${color.G60};
+  }
+`;

--- a/apps/mobile/src/constants/common/constant.ts
+++ b/apps/mobile/src/constants/common/constant.ts
@@ -1,7 +1,14 @@
+import { Side } from '@/types/manage/client';
+
 export const ROUTES = {
   LOGIN: '/',
   HOME: '/home',
   MANAGE: '/manage',
   SHOP: '/shop',
   MY: '/my',
+};
+
+export const SIDE: Record<Side, string> = {
+  GROOM: '신랑',
+  BRIDE: '신부',
 };

--- a/apps/mobile/src/types/manage/client.ts
+++ b/apps/mobile/src/types/manage/client.ts
@@ -1,0 +1,1 @@
+export type Side = 'GROOM' | 'BRIDE';

--- a/apps/mobile/src/utils/formatSide.ts
+++ b/apps/mobile/src/utils/formatSide.ts
@@ -1,6 +1,0 @@
-import { Side } from '@/types/manage/client';
-
-export const formatSide: Record<Side, string> = {
-  GROOM: '신랑',
-  BRIDE: '신부',
-};

--- a/apps/mobile/src/utils/formatSide.ts
+++ b/apps/mobile/src/utils/formatSide.ts
@@ -1,0 +1,6 @@
+import { Side } from '@/types/manage/client';
+
+export const formatSide: Record<Side, string> = {
+  GROOM: '신랑',
+  BRIDE: '신부',
+};

--- a/packages/icon/index.ts
+++ b/packages/icon/index.ts
@@ -11,3 +11,5 @@ export { default as IconProfile } from './src/IconProfile';
 export { default as IconFolder } from './src/IconFolder';
 export { default as IconBoldShare } from './src/IconBoldShare';
 export { default as IconBoldLetter } from './src/IconBoldLetter';
+export { default as IconSearch } from './src/IconSearch';
+export { default as IconPencil } from './src/IconPencil';

--- a/packages/icon/src/IconPencil.tsx
+++ b/packages/icon/src/IconPencil.tsx
@@ -1,0 +1,36 @@
+import type { SVGProps } from 'react';
+import React from 'react';
+
+const IconPencil = (props: SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <g clipPath="url(#clip0_869_3921)">
+      <path opacity="0.36" d="M16 0H0V16H16V0Z" fill="white" />
+      <path
+        d="M4.81038 14.6663H1.33301V11.189L10.7845 1.73748C11.0451 1.47842 11.3976 1.33301 11.7651 1.33301C12.1326 1.33301 12.4851 1.47842 12.7457 1.73748L14.2619 3.25362C14.5209 3.51423 14.6663 3.86677 14.6663 4.23424C14.6663 4.6017 14.5209 4.95424 14.2619 5.21485L4.81038 14.6663Z"
+        stroke="#FFC0CF"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M4.81038 14.6668L1.33301 11.1895V14.6668H4.81038Z"
+        stroke="#FFC0CF"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M9.67871 2.84329L13.1561 6.32066L14.2619 5.21485C14.5209 4.95424 14.6664 4.6017 14.6664 4.23424C14.6664 3.86677 14.5209 3.51423 14.2619 3.25362L12.7458 1.73748C12.4851 1.47842 12.1326 1.33301 11.7651 1.33301C11.3977 1.33301 11.0451 1.47842 10.7845 1.73748L9.67871 2.84329Z"
+        stroke="#FFC0CF"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </g>
+    <defs>
+      <clipPath id="clip0_869_3921">
+        <rect width="16" height="16" fill="white" />
+      </clipPath>
+    </defs>
+  </svg>
+);
+
+export default IconPencil;

--- a/packages/icon/src/IconSearch.tsx
+++ b/packages/icon/src/IconSearch.tsx
@@ -1,0 +1,29 @@
+import type { SVGProps } from 'react';
+import React from 'react';
+
+const IconSearch = (props: SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <g clipPath="url(#clip0_1263_3881)">
+      <path
+        d="M6.66732 11.9997C9.61284 11.9997 12.0007 9.61186 12.0007 6.66634C12.0007 3.72082 9.61284 1.33301 6.66732 1.33301C3.7218 1.33301 1.33398 3.72082 1.33398 6.66634C1.33398 9.61186 3.7218 11.9997 6.66732 11.9997Z"
+        stroke="#FFC0CF"
+        strokeWidth="2"
+        strokeMiterlimit="10"
+      />
+      <path
+        d="M14.666 14.667L10.666 10.667"
+        stroke="#FFC0CF"
+        strokeWidth="2"
+        strokeLinecap="square"
+        strokeLinejoin="round"
+      />
+    </g>
+    <defs>
+      <clipPath id="clip0_1263_3881">
+        <rect width="16" height="16" fill="white" />
+      </clipPath>
+    </defs>
+  </svg>
+);
+
+export default IconSearch;

--- a/packages/ui/src/Button/ActionButton.tsx
+++ b/packages/ui/src/Button/ActionButton.tsx
@@ -9,7 +9,7 @@ type Props = {
   children: ReactNode;
   icon?: ButtonIcon;
   width?: CSSProperties['width'];
-  background: string;
+  background?: string;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 const ActionButton = ({
@@ -19,7 +19,7 @@ const ActionButton = ({
   icon = 'NONE',
   style,
   disabled,
-  background,
+  background = color.primary,
 }: Props) => {
   return (
     <StyledActionButton

--- a/packages/ui/src/Button/ActionButton.tsx
+++ b/packages/ui/src/Button/ActionButton.tsx
@@ -1,14 +1,15 @@
 import { ButtonHTMLAttributes, ReactNode, CSSProperties } from 'react';
 import { ButtonIcon } from './button.type';
 import styled from 'styled-components';
-import { flex } from '@merried/utils';
 import { color } from '@merried/design-system';
 import { IconAdd } from '@merried/icon';
+import Text from '../Text/Text';
 
 type Props = {
   children: ReactNode;
   icon?: ButtonIcon;
   width?: CSSProperties['width'];
+  background: string;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 const ActionButton = ({
@@ -18,22 +19,30 @@ const ActionButton = ({
   icon = 'NONE',
   style,
   disabled,
+  background,
 }: Props) => {
   return (
-    <StyledActionButton style={{ width, ...style }} onClick={onClick} disabled={disabled}>
+    <StyledActionButton
+      style={{ width, ...style }}
+      onClick={onClick}
+      disabled={disabled}
+      background={background}
+    >
       {icon === 'ADD_ICON' && <IconAdd color={color.G0} width={12} height={12} />}
-      {children}
+      <Text fontType="Button3" color={color.G0}>
+        {children}
+      </Text>
     </StyledActionButton>
   );
 };
 
 export default ActionButton;
 
-const StyledActionButton = styled.button`
+const StyledActionButton = styled.button<{ background: string }>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background-color: ${color.primary};
+  background-color: ${(props) => props.background};
   gap: 8px;
   border-radius: 999px;
   height: 34px;


### PR DESCRIPTION
## 📄 Summary

> 참석자 관리 페이지를퍼블리싱 했습니다.

<br>

## 🔨 Tasks

- 검색 인풋 컴포넌트 개발
- 리스트 컴포넌트 개발
- 페이지 퍼블리싱
- 사용하는 아이콘 컴포넌트 추가
- Action Button 수정

<br>

## 🙋🏻 More

https://github.com/user-attachments/assets/9408d1d9-cace-48db-9c70-28cc24f13299



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 참석자 관리 페이지에 구조화된 레이아웃과 UI가 추가되었습니다.
    - 참석자 목록을 검색하고 확인할 수 있는 기능이 도입되었습니다.
    - 참석자 추가 버튼과 참석자 리스트, 검색 입력창이 제공됩니다.
    - 참석자 리스트에 이름, 참석 여부, 축의금, 식권 정보를 표시합니다.
    - 검색 및 연필 아이콘이 새롭게 추가되었습니다.

- **스타일**
    - 주요 UI 컴포넌트에 맞춤 스타일이 적용되었습니다.

- **버그 수정**
    - ActionButton의 배경색 지정 방식이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->