### PR TITLE
feat(packages): insert Photo 컴포넌트 추가

### DIFF
--- a/apps/web/src/components/common/InsertPhoto/InsertPhoto.tsx
+++ b/apps/web/src/components/common/InsertPhoto/InsertPhoto.tsx
@@ -20,6 +20,16 @@ const InsertPhoto = ({ size = 'SMALL', value, onChange, disabled = false }: Prop
     const files = Array.from(e.target.files ?? []);
     if (files.length === 0) return;
 
+    if (size === 'SMALL') {
+      const file = files[0];
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        onChange([reader.result as string]);
+      };
+      reader.readAsDataURL(file);
+      return;
+    }
+
     const current = value ?? [];
     const validFiles = files.slice(0, MAX_FILES - current.length);
 
@@ -92,8 +102,8 @@ const StyledImageWrapper = styled.div<{ $size: 'SMALL' | 'BIG' }>`
   overflow: hidden;
 
   ${({ $size }) => `
-    width: ${$size === 'SMALL' ? '100%' : '100px'};
-    height: ${$size === 'SMALL' ? '100%' : '100px'};
+    width: ${$size === 'SMALL' ? '140px' : '100px'};
+    height: ${$size === 'SMALL' ? '140px' : '100px'};
     border-radius: ${$size === 'SMALL' ? '8px' : '4px'};
   `}
 `;

--- a/apps/web/src/components/common/InsertPhoto/InsertPhoto.tsx
+++ b/apps/web/src/components/common/InsertPhoto/InsertPhoto.tsx
@@ -104,6 +104,7 @@ const StyledInsertPhoto = styled.div<{ $size: 'SMALL' | 'BIG' }>`
         grid-template-columns: repeat(3, 100px);
         gap: 16px;
         padding: 20px 26px;
+        cursor: pointer;
       `}
 `;
 

--- a/apps/web/src/components/common/InsertPhoto/InsertPhoto.tsx
+++ b/apps/web/src/components/common/InsertPhoto/InsertPhoto.tsx
@@ -2,15 +2,16 @@ import { color } from '@merried/design-system';
 import { flex } from '@merried/utils';
 import { styled } from 'styled-components';
 import { IconCircleAdd, IconDelete } from '@merried/icon';
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 
 interface Props {
   size?: 'SMALL' | 'BIG';
+  value: string | null;
+  onChange: (image: string | null) => void;
   disabled?: boolean;
 }
 
-const InsertPhoto = ({ size = 'SMALL', disabled = false }: Props) => {
-  const [image, setImage] = useState<string | null>(null);
+const InsertPhoto = ({ size = 'SMALL', value, onChange, disabled = false }: Props) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -19,14 +20,15 @@ const InsertPhoto = ({ size = 'SMALL', disabled = false }: Props) => {
 
     const reader = new FileReader();
     reader.onloadend = () => {
-      setImage(reader.result as string);
+      const result = reader.result as string;
+      onChange(result);
     };
     reader.readAsDataURL(file);
   };
 
   const handleRemove = (e: React.MouseEvent) => {
     e.stopPropagation();
-    setImage(null);
+    onChange(null);
   };
 
   return (
@@ -38,9 +40,9 @@ const InsertPhoto = ({ size = 'SMALL', disabled = false }: Props) => {
         style={{ display: 'none' }}
         onChange={handleUpload}
       />
-      {image ? (
+      {value ? (
         <>
-          <StyledImage src={image} alt="preview" />
+          <StyledImage src={value} alt="preview" />
           <IconDelete onClick={handleRemove} style={{ position: 'absolute' }} />
         </>
       ) : (

--- a/apps/web/src/components/common/InsertPhoto/InsertPhoto.tsx
+++ b/apps/web/src/components/common/InsertPhoto/InsertPhoto.tsx
@@ -1,7 +1,7 @@
 import { color } from '@merried/design-system';
 import { flex } from '@merried/utils';
 import { styled } from 'styled-components';
-import { IconCircleAdd } from '@merried/icon';
+import { IconCircleAdd, IconDelete } from '@merried/icon';
 import { useRef, useState } from 'react';
 
 interface Props {
@@ -24,6 +24,11 @@ const InsertPhoto = ({ size = 'SMALL', disabled = false }: Props) => {
     reader.readAsDataURL(file);
   };
 
+  const handleRemove = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setImage(null);
+  };
+
   return (
     <StyledInsertPhoto onClick={() => inputRef.current?.click()} $size={size}>
       <input
@@ -34,11 +39,10 @@ const InsertPhoto = ({ size = 'SMALL', disabled = false }: Props) => {
         onChange={handleUpload}
       />
       {image ? (
-        <img
-          src={image}
-          alt="preview"
-          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
-        />
+        <>
+          <StyledImage src={image} alt="preview" />
+          <IconDelete onClick={handleRemove} style={{ position: 'absolute' }} />
+        </>
       ) : (
         <IconCircleAdd />
       )}
@@ -59,4 +63,12 @@ const StyledInsertPhoto = styled.div<{
   height: 140px;
 
   cursor: pointer;
+`;
+
+const StyledImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  position: relative;
+  border-radius: 8px;
 `;

--- a/apps/web/src/components/common/InsertPhoto/InsertPhoto.tsx
+++ b/apps/web/src/components/common/InsertPhoto/InsertPhoto.tsx
@@ -76,7 +76,7 @@ const InsertPhoto = ({ size = 'SMALL', value, onChange, disabled = false }: Prop
           </StyledImageWrapper>
         ))
       ) : (
-        <IconCircleAdd />
+        <StyledCircleAddIcon />
       )}
     </StyledInsertPhoto>
   );
@@ -84,28 +84,44 @@ const InsertPhoto = ({ size = 'SMALL', value, onChange, disabled = false }: Prop
 
 export default InsertPhoto;
 
-const StyledInsertPhoto = styled.div<{
-  $size: 'SMALL' | 'BIG';
-}>`
-  ${flex({ justifyContent: 'center', alignItems: 'center' })}
+const StyledInsertPhoto = styled.div<{ $size: 'SMALL' | 'BIG' }>`
+  position: relative;
   border-radius: 8px;
   border: 1px dashed ${color.G80};
   background: ${color.G0};
-  width: ${({ $size }) => ($size === 'SMALL' ? '140px' : '100%')};
   min-height: 140px;
 
-  cursor: pointer;
+  ${({ $size }) =>
+    $size === 'SMALL'
+      ? `
+        ${flex({ justifyContent: 'center', alignItems: 'center' })};
+        width: 140px;
+        height: 140px;
+      `
+      : `
+        display: grid;
+        width: 384px;
+        grid-template-columns: repeat(3, 100px);
+        gap: 16px;
+        padding: 20px 26px;
+      `}
 `;
 
 const StyledImageWrapper = styled.div<{ $size: 'SMALL' | 'BIG' }>`
   position: relative;
   overflow: hidden;
+  width: 100%;
 
-  ${({ $size }) => `
-    width: ${$size === 'SMALL' ? '140px' : '100px'};
-    height: ${$size === 'SMALL' ? '140px' : '100px'};
-    border-radius: ${$size === 'SMALL' ? '8px' : '4px'};
-  `}
+  ${({ $size }) =>
+    $size === 'SMALL'
+      ? `
+        height: 140px;
+        border-radius: 8px;
+      `
+      : `
+        height: 100px;
+        border-radius: 4px;
+      `}
 `;
 
 const StyledImage = styled.img`
@@ -115,6 +131,15 @@ const StyledImage = styled.img`
 `;
 
 const StyledDeleteIcon = styled(IconDelete)`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1;
+  cursor: pointer;
+`;
+
+const StyledCircleAddIcon = styled(IconCircleAdd)`
   position: absolute;
   top: 50%;
   left: 50%;

--- a/apps/web/src/components/common/InsertPhoto/InsertPhoto.tsx
+++ b/apps/web/src/components/common/InsertPhoto/InsertPhoto.tsx
@@ -1,0 +1,32 @@
+import { color } from '@merried/design-system';
+import { flex } from '@merried/utils';
+import { styled } from 'styled-components';
+import { IconCircleAdd } from '@merried/icon';
+
+interface Props {
+  size?: 'SMALL' | 'BIG';
+  value?: File[] | null;
+  onChange?: (file: File | null) => void;
+  disabled?: boolean;
+}
+
+const InsertPhoto = ({ size = 'SMALL', value, onChange, disabled = false }: Props) => {
+  return (
+    <StyledInsertPhoto $size={size}>
+      <IconCircleAdd />
+    </StyledInsertPhoto>
+  );
+};
+
+export default InsertPhoto;
+
+const StyledInsertPhoto = styled.div<{
+  $size: 'SMALL' | 'BIG';
+}>`
+  ${flex({ justifyContent: 'center', alignItems: 'center' })}
+  border-radius: 8px;
+  border: 1px dashed ${color.G80};
+  background: ${color.G0};
+  width: ${({ $size }) => ($size === 'SMALL' ? '140px' : '384px')};
+  height: 140px;
+`;

--- a/apps/web/src/components/common/InsertPhoto/InsertPhoto.tsx
+++ b/apps/web/src/components/common/InsertPhoto/InsertPhoto.tsx
@@ -2,18 +2,46 @@ import { color } from '@merried/design-system';
 import { flex } from '@merried/utils';
 import { styled } from 'styled-components';
 import { IconCircleAdd } from '@merried/icon';
+import { useRef, useState } from 'react';
 
 interface Props {
   size?: 'SMALL' | 'BIG';
-  value?: File[] | null;
-  onChange?: (file: File | null) => void;
   disabled?: boolean;
 }
 
-const InsertPhoto = ({ size = 'SMALL', value, onChange, disabled = false }: Props) => {
+const InsertPhoto = ({ size = 'SMALL', disabled = false }: Props) => {
+  const [image, setImage] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setImage(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+  };
+
   return (
-    <StyledInsertPhoto $size={size}>
-      <IconCircleAdd />
+    <StyledInsertPhoto onClick={() => inputRef.current?.click()} $size={size}>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        style={{ display: 'none' }}
+        onChange={handleUpload}
+      />
+      {image ? (
+        <img
+          src={image}
+          alt="preview"
+          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+        />
+      ) : (
+        <IconCircleAdd />
+      )}
     </StyledInsertPhoto>
   );
 };
@@ -29,4 +57,6 @@ const StyledInsertPhoto = styled.div<{
   background: ${color.G0};
   width: ${({ $size }) => ($size === 'SMALL' ? '140px' : '384px')};
   height: 140px;
+
+  cursor: pointer;
 `;

--- a/apps/web/src/components/common/InsertPhoto/InsertPhoto.tsx
+++ b/apps/web/src/components/common/InsertPhoto/InsertPhoto.tsx
@@ -130,7 +130,7 @@ const StyledImage = styled.img`
   object-fit: cover;
 `;
 
-const StyledDeleteIcon = styled(IconDelete)`
+const centerAbsolute = `
   position: absolute;
   top: 50%;
   left: 50%;
@@ -139,11 +139,10 @@ const StyledDeleteIcon = styled(IconDelete)`
   cursor: pointer;
 `;
 
+const StyledDeleteIcon = styled(IconDelete)`
+  ${centerAbsolute}
+`;
+
 const StyledCircleAddIcon = styled(IconCircleAdd)`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 1;
-  cursor: pointer;
+  ${centerAbsolute}
 `;

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -1,2 +1,1 @@
 export { default as Header } from './Header/Header';
-export { default as InsertPhoto } from './InsertPhoto/InsertPhoto';

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -1,0 +1,2 @@
+export { default as Header } from './Header/Header';
+export { default as InsertPhoto } from './InsertPhoto/InsertPhoto';

--- a/apps/web/src/layouts/AppLayout.tsx
+++ b/apps/web/src/layouts/AppLayout.tsx
@@ -3,7 +3,7 @@
 import type { ReactNode } from 'react';
 import { styled } from 'styled-components';
 import { flex } from '@merried/utils';
-import Header from '@/components/common/Header/Header';
+import { Header } from '@/components/common';
 
 interface Props {
   children: ReactNode;

--- a/packages/icon/index.ts
+++ b/packages/icon/index.ts
@@ -11,3 +11,4 @@ export { default as IconProfile } from './src/IconProfile';
 export { default as IconFolder } from './src/IconFolder';
 export { default as IconBoldShare } from './src/IconBoldShare';
 export { default as IconBoldLetter } from './src/IconBoldLetter';
+export { default as IconCircleAdd } from './src/IconCircleAdd';

--- a/packages/icon/index.ts
+++ b/packages/icon/index.ts
@@ -12,3 +12,4 @@ export { default as IconFolder } from './src/IconFolder';
 export { default as IconBoldShare } from './src/IconBoldShare';
 export { default as IconBoldLetter } from './src/IconBoldLetter';
 export { default as IconCircleAdd } from './src/IconCircleAdd';
+export { default as IconDelete } from './src/IconDelete';

--- a/packages/icon/src/IconCircleAdd.tsx
+++ b/packages/icon/src/IconCircleAdd.tsx
@@ -1,0 +1,23 @@
+import type { SVGProps } from 'react';
+import React from 'react';
+
+const IconCircleAdd = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    width={36}
+    height={36}
+    viewBox="0 0 36 36"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <circle cx="18" cy="18" r="15" fill="#FFC0CF" />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M19.5 16.5002V10.5H16.5V16.5002H10.5V19.5002H16.5V25.5003H19.5V19.5002H25.5003V16.5002H19.5Z"
+      fill="white"
+    />
+  </svg>
+);
+
+export default IconCircleAdd;

--- a/packages/icon/src/IconDelete.tsx
+++ b/packages/icon/src/IconDelete.tsx
@@ -12,14 +12,14 @@ const IconDelete = (props: SVGProps<SVGSVGElement>) => (
   >
     <path
       d="M1.33398 1.33398L14.6673 14.6673"
-      stroke="currentColor"
+      stroke="#FFF"
       strokeWidth={1.6}
       strokeLinecap="square"
       strokeLinejoin="round"
     />
     <path
       d="M14.6673 1.33398L1.33398 14.6673"
-      stroke="currentColor"
+      stroke="#FFF"
       strokeWidth={1.6}
       strokeLinecap="square"
       strokeLinejoin="round"

--- a/packages/icon/src/IconDelete.tsx
+++ b/packages/icon/src/IconDelete.tsx
@@ -1,0 +1,30 @@
+import type { SVGProps } from 'react';
+import React from 'react';
+
+const IconDelete = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 16 16"
+    width={16}
+    height={16}
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M1.33398 1.33398L14.6673 14.6673"
+      stroke="currentColor"
+      strokeWidth={1.6}
+      strokeLinecap="square"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M14.6673 1.33398L1.33398 14.6673"
+      stroke="currentColor"
+      strokeWidth={1.6}
+      strokeLinecap="square"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default IconDelete;

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -8,3 +8,4 @@ export { default as Row } from './src/Flex/Row';
 export { default as Column } from './src/Flex/Column';
 export { default as Text } from './src/Text/Text';
 export { default as LoginButton } from './src/Button/LoginButton';
+export { default as InsertPhoto } from './src/InsertPhoto/InsertPhoto';

--- a/packages/ui/src/InsertPhoto/InsertPhoto.tsx
+++ b/packages/ui/src/InsertPhoto/InsertPhoto.tsx
@@ -79,6 +79,7 @@ const InsertPhoto = ({
       {value ? (
         value.map((src, index) => (
           <StyledImageWrapper key={index} $size={size}>
+            <StyledOverlay />
             <StyledImage src={src} alt={`uploaded-${index}`} />
             <StyledDeleteIcon onClick={handleRemove(index)} />
           </StyledImageWrapper>
@@ -133,11 +134,23 @@ const StyledImageWrapper = styled.div<{ $size: 'SMALL' | 'BIG' }>`
       `}
 `;
 
+const StyledOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.1);
+  z-index: 1;
+  pointer-events: none;
+`;
+
 const StyledImage = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;
-  opacity: 0.9;
 `;
 
 const centerAbsolute = `

--- a/packages/ui/src/InsertPhoto/InsertPhoto.tsx
+++ b/packages/ui/src/InsertPhoto/InsertPhoto.tsx
@@ -21,7 +21,7 @@ const InsertPhoto = ({ size = 'SMALL', value, onChange, disabled = false }: Prop
     if (files.length === 0) return;
 
     if (size === 'SMALL') {
-      const file = files[0];
+      const file = files[0]!;
       const reader = new FileReader();
       reader.onloadend = () => {
         onChange([reader.result as string]);

--- a/packages/ui/src/InsertPhoto/InsertPhoto.tsx
+++ b/packages/ui/src/InsertPhoto/InsertPhoto.tsx
@@ -9,11 +9,16 @@ interface Props {
   value: string[] | null;
   onChange: (image: string[] | null) => void;
   disabled?: boolean;
+  maxFiles?: number;
 }
 
-const MAX_FILES = 20;
-
-const InsertPhoto = ({ size = 'SMALL', value, onChange, disabled = false }: Props) => {
+const InsertPhoto = ({
+  size = 'SMALL',
+  value,
+  onChange,
+  disabled = false,
+  maxFiles = 20,
+}: Props) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -31,7 +36,7 @@ const InsertPhoto = ({ size = 'SMALL', value, onChange, disabled = false }: Prop
     }
 
     const current = value ?? [];
-    const validFiles = files.slice(0, MAX_FILES - current.length);
+    const validFiles = files.slice(0, maxFiles - current.length);
 
     const readers = validFiles.map(
       (file) =>

--- a/packages/ui/src/InsertPhoto/InsertPhoto.tsx
+++ b/packages/ui/src/InsertPhoto/InsertPhoto.tsx
@@ -17,7 +17,7 @@ const InsertPhoto = ({
   value,
   onChange,
   disabled = false,
-  maxFiles = 20,
+  maxFiles = size === 'SMALL' ? 1 : 20,
 }: Props) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -63,6 +63,8 @@ const InsertPhoto = ({
     onChange(updated.length > 0 ? updated : null);
   };
 
+  const isMaxFilesReached = (value?.length ?? 0) >= maxFiles;
+
   return (
     <StyledInsertPhoto onClick={() => inputRef.current?.click()} $size={size}>
       <input
@@ -72,6 +74,7 @@ const InsertPhoto = ({
         multiple={size === 'BIG'}
         style={{ display: 'none' }}
         onChange={handleUpload}
+        disabled={isMaxFilesReached || disabled}
       />
       {value ? (
         value.map((src, index) => (

--- a/packages/ui/src/InsertPhoto/InsertPhoto.tsx
+++ b/packages/ui/src/InsertPhoto/InsertPhoto.tsx
@@ -137,6 +137,7 @@ const StyledImage = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;
+  opacity: 0.9;
 `;
 
 const centerAbsolute = `


### PR DESCRIPTION
## 📄 Summary

> insert Photo 컴포넌트를 퍼블리싱하고 기능을 추가했습니다.

<br>

## 🔨 Tasks

- 사진 업로드 기능
- 업로드된 사진 삭제 기능
- size가 BIG일 때는 여러 사진 입력 가능
- size가 BIG일 때는 3열 그리드 형태로 표시
- 업로드된 사진 갯수에 따른 disabled 처리
- 각종 BIG일 때와 SMALL일 때 퍼블리싱
- IconCircleAdd 추가
- IconDelete 추가

<br>

## 🙋🏻 More
![image](https://github.com/user-attachments/assets/28108fd6-067d-42c9-bd63-c52c4417c146)
투명도 적용 결과
![image](https://github.com/user-attachments/assets/f1eddbc3-7dba-4dd4-a62e-508b71d65a3a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 이미지 업로드 및 삭제가 가능한 InsertPhoto 컴포넌트가 추가되었습니다. 두 가지 크기(SMALL, BIG)를 지원하며, 여러 이미지를 업로드하거나 삭제할 수 있습니다.
	- 새로운 아이콘(IconCircleAdd, IconDelete)이 추가되어 이미지 추가 및 삭제 버튼 등에서 사용됩니다.
- **리팩터**
	- Header 컴포넌트의 import 경로가 개선되어, 더 간편하게 공통 컴포넌트에서 사용할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->