### PR TITLE
feat(web): 청접장 만들기 옵션 중 사진 추가 관련 옵션 퍼블리싱

### DIFF
--- a/apps/web/src/components/form/Gallery/index.tsx
+++ b/apps/web/src/components/form/Gallery/index.tsx
@@ -1,0 +1,50 @@
+import { color } from '@merried/design-system';
+import { Column, Row, ToggleButton, Text, Input, InsertPhoto } from '@merried/ui';
+import { flex } from '@merried/utils';
+import { IconDragHandle } from '@merried/icon';
+import { useState } from 'react';
+import { styled } from 'styled-components';
+
+const Gallery = () => {
+  const [image, setImage] = useState<string[] | null>(null);
+
+  return (
+    <StyledGallery>
+      <Column gap={28}>
+        <Row gap={8}>
+          <ToggleButton isOpen={false} />
+          <Text fontType="H3" color={color.G900}>
+            갤러리
+          </Text>
+        </Row>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            제목
+          </Text>
+          <Input width={384} platform="DESKTOP" placeholder="제목을 입력해주세요" />
+        </Column>
+        <Column gap={16}>
+          <InsertPhoto size="BIG" value={image} onChange={setImage} />
+          <Column gap={4}>
+            <Text fontType="P3" color={color.G80}>
+              · 1장당 100MB까지 업로드 가능합니다.
+            </Text>
+            <Text fontType="P3" color={color.G80}>
+              · 최대 20장 업로드 가능합니다.
+            </Text>
+          </Column>
+        </Column>
+      </Column>
+      <IconDragHandle />
+    </StyledGallery>
+  );
+};
+
+export default Gallery;
+
+const StyledGallery = styled.div`
+  ${flex({ justifyContent: 'space-between', alignItems: 'flex-start' })}
+  padding: 28px 20px;
+  border-radius: 8px;
+  background: ${color.G0};
+`;

--- a/apps/web/src/components/form/GalleryOption/index.tsx
+++ b/apps/web/src/components/form/GalleryOption/index.tsx
@@ -5,11 +5,11 @@ import { IconDragHandle } from '@merried/icon';
 import { useState } from 'react';
 import { styled } from 'styled-components';
 
-const Gallery = () => {
+const GalleryOption = () => {
   const [image, setImage] = useState<string[] | null>(null);
 
   return (
-    <StyledGallery>
+    <StyledGalleryOption>
       <Column gap={28}>
         <Row gap={8}>
           <ToggleButton isOpen={false} />
@@ -36,13 +36,13 @@ const Gallery = () => {
         </Column>
       </Column>
       <IconDragHandle />
-    </StyledGallery>
+    </StyledGalleryOption>
   );
 };
 
-export default Gallery;
+export default GalleryOption;
 
-const StyledGallery = styled.div`
+const StyledGalleryOption = styled.div`
   ${flex({ justifyContent: 'space-between', alignItems: 'flex-start' })}
   padding: 28px 20px;
   border-radius: 8px;

--- a/apps/web/src/components/form/UrlShareStyleOption/index.tsx
+++ b/apps/web/src/components/form/UrlShareStyleOption/index.tsx
@@ -1,0 +1,65 @@
+import { color } from '@merried/design-system';
+import { Column, Row, ToggleButton, Text, Input, InsertPhoto } from '@merried/ui';
+import { flex } from '@merried/utils';
+import { IconDragHandle } from '@merried/icon';
+import { useState } from 'react';
+import { styled } from 'styled-components';
+
+const UrlShareStyleOption = () => {
+  const [image, setImage] = useState<string[] | null>(null);
+
+  return (
+    <StyledUrlShareStyleOption>
+      <Column gap={28}>
+        <Row gap={8}>
+          <ToggleButton isOpen={false} />
+          <Text fontType="H3" color={color.G900}>
+            URL 공유 스타일 설정
+          </Text>
+        </Row>
+        <Column gap={12}>
+          <Column gap={8}>
+            <Text fontType="P3" color={color.G900}>
+              썸네일
+            </Text>
+            <InsertPhoto size="SMALL" value={image} onChange={setImage} />
+          </Column>
+          <Column gap={4}>
+            <Text fontType="P3" color={color.G80}>
+              · URL 공유 수정 시 반영까지{' '}
+              <Text fontType="P3" color={color.primary}>
+                1시간 이상
+              </Text>{' '}
+              소요됩니다.
+            </Text>
+            <Text fontType="P3" color={color.G80}>
+              · 썸네일은 100MB이내로 첨부바랍니다.
+            </Text>
+          </Column>
+        </Column>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            제목
+          </Text>
+          <Input width={384} platform="DESKTOP" placeholder="제목을 입력해주세요" />
+        </Column>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            내용
+          </Text>
+          <Input width={384} platform="DESKTOP" placeholder="내용을 입력해주세요" />
+        </Column>
+      </Column>
+      <IconDragHandle />
+    </StyledUrlShareStyleOption>
+  );
+};
+
+export default UrlShareStyleOption;
+
+const StyledUrlShareStyleOption = styled.div`
+  ${flex({ justifyContent: 'space-between', alignItems: 'flex-start' })}
+  padding: 28px 20px;
+  border-radius: 8px;
+  background: ${color.G0};
+`;

--- a/packages/icon/index.ts
+++ b/packages/icon/index.ts
@@ -15,3 +15,4 @@ export { default as IconCircleAdd } from './src/IconCircleAdd';
 export { default as IconDelete } from './src/IconDelete';
 export { default as IconSearch } from './src/IconSearch';
 export { default as IconPencil } from './src/IconPencil';
+export { default as IconDragHandle } from './src/IconDragHandle';

--- a/packages/icon/src/IconDragHandle.tsx
+++ b/packages/icon/src/IconDragHandle.tsx
@@ -1,0 +1,34 @@
+import type { SVGProps } from 'react';
+import React from 'react';
+
+const IconDragHandle = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 36 36"
+    width={36}
+    height={36}
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    style={{ cursor: 'pointer' }}
+    {...props}
+  >
+    <mask
+      id="mask0_749_3843"
+      style={{ maskType: 'alpha' }}
+      maskUnits="userSpaceOnUse"
+      x={0}
+      y={0}
+      width={36}
+      height={36}
+    >
+      <rect width={36} height={36} fill="#D9D9D9" />
+    </mask>
+    <g mask="url(#mask0_749_3843)">
+      <path
+        d="M6.75 21.5764V19.692H29.25V21.5764H6.75ZM6.75 16.3072V14.4229H29.25V16.3072H6.75Z"
+        fill="#9F9F9F"
+      />
+    </g>
+  </svg>
+);
+
+export default IconDragHandle;


### PR DESCRIPTION
## 📄 Summary

> 청접장 만들기 옵션 중 사진 추가 관련 옵션 퍼블리싱했습니다.

<br>

## 🔨 Tasks

- 갤러리[8] 퍼블리싱
- URL 공유 스타일 설정[15] 퍼블리싱
- 드래그 아이콘 추가

<br>

## 🙋🏻 More
![image](https://github.com/user-attachments/assets/c06246c8-ebb1-42a5-b6b2-1dbb97de70ba)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - 갤러리 옵션 및 URL 공유 스타일 설정 UI 컴포넌트가 추가되었습니다.
    - 이미지 업로드 및 썸네일 미리보기 기능이 포함되었습니다.
    - 드래그 핸들 아이콘이 새롭게 도입되어 인터페이스 내에서 사용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->