### PR TITLE
feat(mobile): 마이 페이지 퍼블리싱

### DIFF
--- a/apps/mobile/src/app/my/page.tsx
+++ b/apps/mobile/src/app/my/page.tsx
@@ -1,14 +1,34 @@
 'use client';
 
+import MyInfoList from '@/components/my/MyInfoList/MyInfoList';
 import AppLayout from '@/layouts/AppLayout';
 import { color } from '@merried/design-system';
+import { Text } from '@merried/ui';
+import { flex } from '@merried/utils';
+import styled from 'styled-components';
 
 const My = () => {
   return (
-    <AppLayout footer backgroundColor={color.G20}>
-      마이페이지
+    <AppLayout footer backgroundColor={color.G0}>
+      <StyledMy>
+        <Text fontType="H2" color={color.G900}>
+          마이페이지
+        </Text>
+        <MyInfoList />
+      </StyledMy>
     </AppLayout>
   );
 };
 
 export default My;
+
+const StyledMy = styled.div`
+  ${flex({
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+  })}
+  width: 100%;
+  gap: 49px;
+  padding: 67px 18px 115px;
+`;

--- a/apps/mobile/src/app/my/page.tsx
+++ b/apps/mobile/src/app/my/page.tsx
@@ -29,6 +29,6 @@ const StyledMy = styled.div`
     justifyContent: 'flex-start',
   })}
   width: 100%;
-  gap: 49px;
-  padding: 67px 18px 115px;
+  gap: 36px;
+  padding: 71px 18px 115px;
 `;

--- a/apps/mobile/src/components/my/ListItem/ListItem.tsx
+++ b/apps/mobile/src/components/my/ListItem/ListItem.tsx
@@ -1,0 +1,41 @@
+import { color } from '@merried/design-system';
+import { IconArrow } from '@merried/icon';
+import { Row, Text } from '@merried/ui';
+import { flex } from '@merried/utils';
+import { SVGProps } from 'react';
+import styled from 'styled-components';
+
+interface ListItemProps {
+  icon: React.ComponentType<SVGProps<SVGSVGElement>>;
+  title: string;
+}
+
+const ListItem = ({ icon: Icon, title }: ListItemProps) => {
+  const handleItemClick = () => {
+    alert('추후 개발 예정입니다.');
+  };
+
+  return (
+    <StyledListItem onClick={handleItemClick}>
+      <Row gap={8} alignItems="center">
+        <Icon width={22} height={22} />
+        <Text fontType="P3" color={color.G300}>
+          {title}
+        </Text>
+      </Row>
+      <IconArrow width={18} height={18} direction="left" />
+    </StyledListItem>
+  );
+};
+
+export default ListItem;
+
+const StyledListItem = styled.div`
+  ${flex({
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  })}
+  width: 100%;
+  padding: 8px 0px;
+`;

--- a/apps/mobile/src/components/my/MyInfo/MyInfo.tsx
+++ b/apps/mobile/src/components/my/MyInfo/MyInfo.tsx
@@ -1,5 +1,4 @@
 import { color } from '@merried/design-system';
-import { IconArrow } from '@merried/icon';
 import { BrandBadge, Column, Row, Text } from '@merried/ui';
 import { flex } from '@merried/utils';
 import styled from 'styled-components';
@@ -7,9 +6,9 @@ import styled from 'styled-components';
 const MyInfo = () => {
   return (
     <StyledMyInfo onClick={() => {}}>
-      <Column gap={6}>
+      <Column gap={4}>
         <Row gap={8} alignItems="center">
-          <Text fontType="H3_140per" color={color.G900}>
+          <Text fontType="H3" color={color.G900}>
             박강원님
           </Text>
           <BrandBadge type="NAVER" />
@@ -18,7 +17,11 @@ const MyInfo = () => {
           pkw0227@gmail.com
         </Text>
       </Column>
-      <IconArrow width={18} height={18} direction="left" />
+      <div onClick={() => {}}>
+        <Text fontType="P3" color={color.G100}>
+          로그아웃
+        </Text>
+      </div>
     </StyledMyInfo>
   );
 };

--- a/apps/mobile/src/components/my/MyInfo/MyInfo.tsx
+++ b/apps/mobile/src/components/my/MyInfo/MyInfo.tsx
@@ -1,0 +1,32 @@
+import { color } from '@merried/design-system';
+import { IconArrow } from '@merried/icon';
+import { BrandBadge, Column, Row, Text } from '@merried/ui';
+import { flex } from '@merried/utils';
+import styled from 'styled-components';
+
+const MyInfo = () => {
+  return (
+    <StyledMyInfo onClick={() => {}}>
+      <Column gap={6}>
+        <Row gap={8} alignItems="center">
+          <Text fontType="H3_140per" color={color.G900}>
+            박강원님
+          </Text>
+          <BrandBadge type="NAVER" />
+        </Row>
+        <Text fontType="P3" color={color.G60}>
+          pkw0227@gmail.com
+        </Text>
+      </Column>
+      <IconArrow width={18} height={18} direction="left" />
+    </StyledMyInfo>
+  );
+};
+
+export default MyInfo;
+
+const StyledMyInfo = styled.div`
+  ${flex({ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' })}
+  width: 100%;
+  height: 51px;
+`;

--- a/apps/mobile/src/components/my/MyInfoList/MyInfoList.tsx
+++ b/apps/mobile/src/components/my/MyInfoList/MyInfoList.tsx
@@ -4,6 +4,7 @@ import MyInfo from '../MyInfo/MyInfo';
 import ListItem from '../ListItem/ListItem';
 import { IconHeadset, IconMegaphone } from '@merried/icon';
 import { Column } from '@merried/ui';
+import { flex } from '@merried/utils';
 
 const MyInfoList = () => {
   return (
@@ -21,7 +22,9 @@ const MyInfoList = () => {
 export default MyInfoList;
 
 const StyledMyInfoList = styled.div`
+  ${flex({ flexDirection: 'column', alignItems: 'flex-start' })}
   width: 100%;
+  gap: 16px;
 `;
 
 const Spacer = styled.div`
@@ -30,6 +33,4 @@ const Spacer = styled.div`
   background-color: ${color.G10};
   position: relative;
   left: -18px;
-  margin-top: 24px;
-  margin-bottom: 12px;
 `;

--- a/apps/mobile/src/components/my/MyInfoList/MyInfoList.tsx
+++ b/apps/mobile/src/components/my/MyInfoList/MyInfoList.tsx
@@ -1,0 +1,35 @@
+import { color } from '@merried/design-system';
+import styled from 'styled-components';
+import MyInfo from '../MyInfo/MyInfo';
+import ListItem from '../ListItem/ListItem';
+import { IconHeadset, IconMegaphone } from '@merried/icon';
+import { Column } from '@merried/ui';
+
+const MyInfoList = () => {
+  return (
+    <StyledMyInfoList>
+      <MyInfo />
+      <Spacer />
+      <Column gap={4}>
+        <ListItem icon={IconHeadset} title="고객지원" />
+        <ListItem icon={IconMegaphone} title="공지사항" />
+      </Column>
+    </StyledMyInfoList>
+  );
+};
+
+export default MyInfoList;
+
+const StyledMyInfoList = styled.div`
+  width: 100%;
+`;
+
+const Spacer = styled.div`
+  width: calc(100% + 36px);
+  height: 10px;
+  background-color: ${color.G10};
+  position: relative;
+  left: -18px;
+  margin-top: 24px;
+  margin-bottom: 12px;
+`;

--- a/packages/icon/index.ts
+++ b/packages/icon/index.ts
@@ -15,3 +15,5 @@ export { default as IconCircleAdd } from './src/IconCircleAdd';
 export { default as IconDelete } from './src/IconDelete';
 export { default as IconSearch } from './src/IconSearch';
 export { default as IconPencil } from './src/IconPencil';
+export { default as IconHeadset } from './src/IconHeadset';
+export { default as IconMegaphone } from './src/IconMegaphone';

--- a/packages/icon/src/IconHeadset.tsx
+++ b/packages/icon/src/IconHeadset.tsx
@@ -1,0 +1,32 @@
+import type { SVGProps } from 'react';
+import React from 'react';
+
+const IconHeadset = (props: SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <g clipPath="url(#clip0_183_1378)">
+      <path
+        d="M17.4163 8.25C17.4163 5.21243 14.5435 2.75 10.9997 2.75C7.45585 2.75 4.58301 5.21243 4.58301 8.25"
+        stroke="#686868"
+        strokeWidth="2"
+      />
+      <path
+        d="M17.1113 7.33301V7.33301C18.7989 7.33301 20.1669 8.70103 20.1669 10.3886V11.1525C20.1669 12.84 18.7989 14.208 17.1113 14.208V14.208V7.33301Z"
+        stroke="#686868"
+        strokeWidth="2"
+      />
+      <path
+        d="M4.88867 7.33301V7.33301C3.20113 7.33301 1.83312 8.70103 1.83312 10.3886V11.1525C1.83312 12.84 3.20113 14.208 4.88867 14.208V14.208V7.33301Z"
+        stroke="#686868"
+        strokeWidth="2"
+      />
+      <path d="M10.2363 18.7913H12.528L17.1113 14.208" stroke="#686868" strokeWidth="2" />
+    </g>
+    <defs>
+      <clipPath id="clip0_183_1378">
+        <rect width="22" height="22" fill="white" />
+      </clipPath>
+    </defs>
+  </svg>
+);
+
+export default IconHeadset;

--- a/packages/icon/src/IconMegaphone.tsx
+++ b/packages/icon/src/IconMegaphone.tsx
@@ -1,0 +1,14 @@
+import type { SVGProps } from 'react';
+import React from 'react';
+
+const IconMegaphone = (props: SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      d="M7.7824 7.07598C11.0308 6.18131 18.0616 4 18.0616 4V17.6223C18.0616 17.6223 11.4702 14.9857 7.7824 13.4611M7.7824 7.07598C4 7.07639 6.19713 7.07598 4 7.07598V12.7046L4.75648 13.4611V18H7.7824V13.4611M7.7824 7.07598V13.4611"
+      stroke="#686868"
+      strokeWidth="1.51296"
+    />
+  </svg>
+);
+
+export default IconMegaphone;

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -10,3 +10,4 @@ export { default as Column } from './src/Flex/Column';
 export { default as Text } from './src/Text/Text';
 export { default as LoginButton } from './src/Button/LoginButton';
 export { default as InsertPhoto } from './src/InsertPhoto/InsertPhoto';
+export { default as BrandBadge} from './src/BrandBadge/BrandBadge'

--- a/packages/ui/src/BrandBadge/BrandBadge.tsx
+++ b/packages/ui/src/BrandBadge/BrandBadge.tsx
@@ -3,11 +3,11 @@ import { flex } from '@merried/utils';
 import styled from 'styled-components';
 import Text from '../Text/Text';
 
-interface BradnBadgeProps {
+interface BrandBadgeProps {
   type: 'KAKAO' | 'NAVER';
 }
 
-const BrandBadge = ({ type }: BradnBadgeProps) => {
+const BrandBadge = ({ type }: BrandBadgeProps) => {
   return (
     <StyledBrandBadge $badgeType={type}>
       <Text fontType="P4" color={type === 'NAVER' ? color.G0 : color.G400}>
@@ -19,7 +19,7 @@ const BrandBadge = ({ type }: BradnBadgeProps) => {
 
 export default BrandBadge;
 
-const StyledBrandBadge = styled.div<{ $badgeType: BradnBadgeProps['type'] }>`
+const StyledBrandBadge = styled.div<{ $badgeType: BrandBadgeProps['type'] }>`
   ${flex({ alignItems: 'center', justifyContent: 'center' })}
   width: 60px;
   height: 28px;

--- a/packages/ui/src/BrandBadge/BrandBadge.tsx
+++ b/packages/ui/src/BrandBadge/BrandBadge.tsx
@@ -1,0 +1,31 @@
+import { color } from '@merried/design-system';
+import { flex } from '@merried/utils';
+import styled from 'styled-components';
+import Text from '../Text/Text';
+
+interface BradnBadgeProps {
+  type: 'KAKAO' | 'NAVER';
+}
+
+const BrandBadge = ({ type }: BradnBadgeProps) => {
+  return (
+    <StyledBrandBadge $badgeType={type}>
+      <Text fontType="P4" color={type === 'NAVER' ? color.G0 : color.G400}>
+        {type === 'NAVER' ? '네이버' : '카카오'}
+      </Text>
+    </StyledBrandBadge>
+  );
+};
+
+export default BrandBadge;
+
+const StyledBrandBadge = styled.div<{ $badgeType: BradnBadgeProps['type'] }>`
+  ${flex({ alignItems: 'center', justifyContent: 'center' })}
+  width: 60px;
+  height: 28px;
+  background: ${({ $badgeType }) =>
+    $badgeType === 'NAVER' ? 'rgba(4, 199, 91, 0.6)' : 'rgba(250, 225, 0, 0.6)'};
+  border-radius: 999px;
+  border: 1px solid
+    ${({ $badgeType }) => ($badgeType === 'NAVER' ? '#04C75B' : '#fae100')};
+`;


### PR DESCRIPTION
## 📄 Summary

> 마이 페이지를 퍼블리싱 했습니다.

<br>

## 🔨 Tasks

- 브랜드 뱃지 컴포넌트 개발
- 마이 페이지 퍼블리싱
- 헤드셋과 확성기 아이콘 컴포넌트 개발

<br>

## 🙋🏻 More
<img width="379" alt="스크린샷 2025-05-08 오후 3 51 34" src="https://github.com/user-attachments/assets/0e348001-d66c-401c-83f6-1676dadd25ed" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 마이페이지 화면의 UI가 개선되어 사용자 정보, 브랜드 배지, 고객지원 및 공지사항 리스트가 추가되었습니다.
    - 새로운 아이콘(헤드셋, 메가폰)이 지원됩니다.
    - 브랜드 구분 배지 컴포넌트가 도입되어, 카카오/네이버 계정임을 시각적으로 표시합니다.

- **스타일**
    - 마이페이지 레이아웃과 구성 요소들의 배경색, 정렬, 패딩 등 디자인이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->