### PR TITLE
feat(web): 청접장 만들기 옵션 중 드롭다운 관련 옵션 퍼블리싱

### DIFF
--- a/apps/web/src/components/form/InvitationSettings/index.tsx
+++ b/apps/web/src/components/form/InvitationSettings/index.tsx
@@ -1,0 +1,57 @@
+import { LETTERING_COLORS } from '@/constants/form/constants';
+import { color } from '@merried/design-system';
+import { Column, Dropdown, Text } from '@merried/ui';
+import { flex } from '@merried/utils';
+import { useState } from 'react';
+import { styled } from 'styled-components';
+
+const InvitationSettings = () => {
+  const [invitationFont, setInvitationFont] = useState<string>('Ownglyph kundo');
+  const [letteringColor, setLetteringColor] = useState<string>(color.letterYellow);
+
+  return (
+    <StyledInvitationSettings>
+      <Column gap={28}>
+        <Text fontType="H3" color={color.G900}>
+          청접장 전체 설정
+          <Text fontType="P3_160per" color={color.red}>
+            *
+          </Text>
+        </Text>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            포인트 색상(메인 화면 적용 X)
+          </Text>
+          <Dropdown
+            option="COLOR"
+            name="invitation-point-color"
+            value={letteringColor}
+            data={LETTERING_COLORS}
+            onChange={setLetteringColor}
+          />
+        </Column>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            폰트(메인 화면 적용 X)
+          </Text>
+          <Dropdown
+            option="DEFAULT"
+            name="invitation-font"
+            value={invitationFont}
+            data={['Ownglyph kundo']}
+            onChange={setInvitationFont}
+          />
+        </Column>
+      </Column>
+    </StyledInvitationSettings>
+  );
+};
+
+export default InvitationSettings;
+
+const StyledInvitationSettings = styled.div`
+  ${flex({ alignItems: 'flex-start' })}
+  padding: 28px 20px;
+  border-radius: 8px;
+  background: ${color.G0};
+`;

--- a/apps/web/src/components/form/InvitationSetupOption/index.tsx
+++ b/apps/web/src/components/form/InvitationSetupOption/index.tsx
@@ -5,12 +5,12 @@ import { flex } from '@merried/utils';
 import { useState } from 'react';
 import { styled } from 'styled-components';
 
-const InvitationSettings = () => {
+const InvitationSetupOption = () => {
   const [invitationFont, setInvitationFont] = useState<string>('Ownglyph kundo');
   const [letteringColor, setLetteringColor] = useState<string>(color.letterYellow);
 
   return (
-    <StyledInvitationSettings>
+    <StyledInvitationSetupOption>
       <Column gap={28}>
         <Text fontType="H3" color={color.G900}>
           청접장 전체 설정
@@ -43,13 +43,13 @@ const InvitationSettings = () => {
           />
         </Column>
       </Column>
-    </StyledInvitationSettings>
+    </StyledInvitationSetupOption>
   );
 };
 
-export default InvitationSettings;
+export default InvitationSetupOption;
 
-const StyledInvitationSettings = styled.div`
+const StyledInvitationSetupOption = styled.div`
   ${flex({ alignItems: 'flex-start' })}
   padding: 28px 20px;
   border-radius: 8px;

--- a/apps/web/src/components/form/MainScreenOption/index.tsx
+++ b/apps/web/src/components/form/MainScreenOption/index.tsx
@@ -36,7 +36,7 @@ const MainScreenOption = () => {
           </Text>
           <Dropdown
             option="DEFAULT"
-            name="letering"
+            name="letering-text"
             value={letteringText}
             data={['THE START OF OUR FOREVER']}
             onChange={setLetteringText}
@@ -48,7 +48,7 @@ const MainScreenOption = () => {
           </Text>
           <Dropdown
             option="COLOR"
-            name="color"
+            name="letering-color"
             value={letteringColor}
             data={LETTERING_COLORS}
             onChange={setLetteringColor}

--- a/apps/web/src/components/form/MainScreenOption/index.tsx
+++ b/apps/web/src/components/form/MainScreenOption/index.tsx
@@ -1,0 +1,77 @@
+import { LETTERING_COLORS } from '@/constants/form/constants';
+import { color } from '@merried/design-system';
+import { Column, Dropdown, InsertPhoto, Text } from '@merried/ui';
+import { flex } from '@merried/utils';
+import { useState } from 'react';
+import { styled } from 'styled-components';
+
+const MainScreenOption = () => {
+  const [image, setImage] = useState<string[] | null>(null);
+  const [letteringText, setLetteringText] = useState<string>('THE START OF OUR FOREVER');
+  const [letteringColor, setLetteringColor] = useState<string>(color.letterYellow);
+
+  return (
+    <StyledMainScreenOption>
+      <Column gap={28}>
+        <Text fontType="H3" color={color.G900}>
+          메인 화면 설정
+          <Text fontType="P3_160per" color={color.red}>
+            *
+          </Text>
+        </Text>
+        <Column gap={12}>
+          <Column gap={8}>
+            <Text fontType="P3" color={color.G900}>
+              사진
+            </Text>
+            <InsertPhoto size="SMALL" value={image} onChange={setImage} />
+          </Column>
+          <Text fontType="P3" color={color.G80}>
+            · 썸네일은 100MB이내로 첨부바랍니다.
+          </Text>
+        </Column>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            레터링 문구(화면 중앙에 위치한 문구입니다)
+          </Text>
+          <Dropdown
+            option="DEFAULT"
+            name="letering"
+            value={letteringText}
+            data={['THE START OF OUR FOREVER']}
+            onChange={setLetteringText}
+          />
+        </Column>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            레터링 색상
+          </Text>
+          <Dropdown
+            option="COLOR"
+            name="color"
+            value={letteringColor}
+            data={LETTERING_COLORS}
+            onChange={setLetteringColor}
+          />
+        </Column>
+        <Column gap={4}>
+          <Text fontType="P3" color={color.G80}>
+            · 1장당 100MB까지 업로드 가능합니다.
+          </Text>
+          <Text fontType="P3" color={color.G80}>
+            · 최대 20장 업로드 가능합니다.
+          </Text>
+        </Column>
+      </Column>
+    </StyledMainScreenOption>
+  );
+};
+
+export default MainScreenOption;
+
+const StyledMainScreenOption = styled.div`
+  ${flex({ alignItems: 'flex-start' })}
+  padding: 28px 20px;
+  border-radius: 8px;
+  background: ${color.G0};
+`;

--- a/apps/web/src/constants/form/constants.ts
+++ b/apps/web/src/constants/form/constants.ts
@@ -1,0 +1,10 @@
+import { color } from '@merried/design-system';
+
+export const LETTERING_COLORS = [
+  color.letterBlue,
+  color.letterGreen,
+  color.letterOrange,
+  color.letterPurple,
+  color.letterRed,
+  color.letterYellow,
+];


### PR DESCRIPTION
## 📄 Summary

> 청접장 만들기 옵션 중 드롭다운 관련 옵션 퍼블리싱했습니다.

<br>

## 🔨 Tasks

- 기본 레터링 색상 상수 추가
- 메인 화면 설정 옵션 퍼블리싱[3]
- 청접장 전체 설정 옵션 퍼블리싱[2]

<br>

## 🙋🏻 More
![image](https://github.com/user-attachments/assets/bf83a5b6-ae28-4d59-b26c-e627c715eb67)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 메인 화면 설정을 위한 옵션 구성 요소가 추가되었습니다.
  - 청첩장 전체 설정을 위한 옵션 구성 요소가 추가되었습니다.
  - 지정된 색상 목록이 새로운 상수로 추가되어 다양한 선택 옵션에서 활용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->