### PR TITLE
feat(web): 청접장 만들기 옵션 중 단순 입력 관련 옵션 퍼블리싱

### DIFF
--- a/apps/web/src/components/form/GuestSnapOption/index.tsx
+++ b/apps/web/src/components/form/GuestSnapOption/index.tsx
@@ -1,0 +1,60 @@
+import { color } from '@merried/design-system';
+import { IconDragHandle } from '@merried/icon';
+import { Column, Input, Row, Text, ToggleButton } from '@merried/ui';
+import { flex } from '@merried/utils';
+import { styled } from 'styled-components';
+
+const GuestSnapOption = () => {
+  return (
+    <StyledGuestSnapOption>
+      <Column gap={28}>
+        <Column gap={8}>
+          <Row gap={8}>
+            <ToggleButton isOpen={false} />
+            <Text fontType="H3" color={color.G900}>
+              게스트 스냅
+            </Text>
+          </Row>
+          <Text fontType="P3" color={color.G80}>
+            하객분들이 찍어주신 사진을 올려주실 수 있는 기능입니다.
+          </Text>
+        </Column>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            제목
+          </Text>
+          <Input width={384} platform="DESKTOP" placeholder="제목을 입력해주세요" />
+        </Column>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            마스터 비밀번호<RequiredMark>*</RequiredMark>
+          </Text>
+          <Input
+            width={384}
+            platform="DESKTOP"
+            placeholder="방명록을 열 비밀번호를 입력해주세요"
+          />
+        </Column>
+      </Column>
+      <IconDragHandle />
+    </StyledGuestSnapOption>
+  );
+};
+
+export default GuestSnapOption;
+
+const StyledGuestSnapOption = styled.div`
+  ${flex({ justifyContent: 'space-between', alignItems: 'flex-start' })}
+  padding: 28px 20px;
+  border-radius: 8px;
+  background: ${color.G0};
+`;
+
+const RequiredMark = styled.span`
+  color: ${color.red};
+  font-family: 'Pretendard Variable';
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 100%;
+`;

--- a/apps/web/src/components/form/GuestbookOption/index.tsx
+++ b/apps/web/src/components/form/GuestbookOption/index.tsx
@@ -1,0 +1,55 @@
+import { color } from '@merried/design-system';
+import { IconDragHandle } from '@merried/icon';
+import { Column, Input, Row, Text, ToggleButton } from '@merried/ui';
+import { flex } from '@merried/utils';
+import { styled } from 'styled-components';
+
+const GuestbookOption = () => {
+  return (
+    <StyledGuestbookOption>
+      <Column gap={28}>
+        <Row gap={8}>
+          <ToggleButton isOpen={false} />
+          <Text fontType="H3" color={color.G900}>
+            방명록
+          </Text>
+        </Row>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            제목
+          </Text>
+          <Input width={384} platform="DESKTOP" placeholder="제목을 입력해주세요" />
+        </Column>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            마스터 비밀번호<RequiredMark>*</RequiredMark>
+          </Text>
+          <Input
+            width={384}
+            platform="DESKTOP"
+            placeholder="방명록을 열 비밀번호를 입력해주세요"
+          />
+        </Column>
+      </Column>
+      <IconDragHandle />
+    </StyledGuestbookOption>
+  );
+};
+
+export default GuestbookOption;
+
+const StyledGuestbookOption = styled.div`
+  ${flex({ justifyContent: 'space-between', alignItems: 'flex-start' })}
+  padding: 28px 20px;
+  border-radius: 8px;
+  background: ${color.G0};
+`;
+
+const RequiredMark = styled.span`
+  color: ${color.red};
+  font-family: 'Pretendard Variable';
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 100%;
+`;

--- a/apps/web/src/components/form/InvitationMessageOption/index.tsx
+++ b/apps/web/src/components/form/InvitationMessageOption/index.tsx
@@ -1,0 +1,56 @@
+import { color } from '@merried/design-system';
+import { IconDragHandle } from '@merried/icon';
+import { Column, Input, Row, Text, ToggleButton } from '@merried/ui';
+import { flex } from '@merried/utils';
+import { styled } from 'styled-components';
+
+const InvitationMessageOption = () => {
+  return (
+    <StyledInvitationMessageOption>
+      <Column gap={28}>
+        <Column gap={8}>
+          <Row gap={8}>
+            <ToggleButton isOpen={false} />
+            <Text fontType="H3" color={color.G900}>
+              초대 글귀
+            </Text>
+          </Row>
+          <Text fontType="P3" color={color.G80}>
+            청첩장을 보시는 분들이 메인 화면 이후 처음으로 보시게 될 글귀입니다.
+          </Text>
+        </Column>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            제목<RequiredMark>*</RequiredMark>
+          </Text>
+          <Input width={384} platform="DESKTOP" placeholder="제목을 입력해주세요" />
+        </Column>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            내용<RequiredMark>*</RequiredMark>
+          </Text>
+          <Input width={384} platform="DESKTOP" placeholder="내용을 입력해주세요" />
+        </Column>
+      </Column>
+      <IconDragHandle />
+    </StyledInvitationMessageOption>
+  );
+};
+
+export default InvitationMessageOption;
+
+const StyledInvitationMessageOption = styled.div`
+  ${flex({ justifyContent: 'space-between', alignItems: 'flex-start' })}
+  padding: 28px 20px;
+  border-radius: 8px;
+  background: ${color.G0};
+`;
+
+const RequiredMark = styled.span`
+  color: ${color.red};
+  font-family: 'Pretendard Variable';
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 100%;
+`;

--- a/apps/web/src/components/form/InvitationNameOption/index.tsx
+++ b/apps/web/src/components/form/InvitationNameOption/index.tsx
@@ -1,0 +1,33 @@
+import { color } from '@merried/design-system';
+import { Column, Input, Text } from '@merried/ui';
+import { flex } from '@merried/utils';
+import { styled } from 'styled-components';
+
+const InvitationNameOption = () => {
+  return (
+    <StyledInvitationNameOption>
+      <Column gap={14}>
+        <Text fontType="H3" color={color.G900}>
+          청접장 명
+          <Text fontType="P2" color={color.red}>
+            *
+          </Text>
+        </Text>
+        <Input
+          width={384}
+          platform="DESKTOP"
+          placeholder="청첩장별로 구별할 수 있는 이름을 적어주세요"
+        />
+      </Column>
+    </StyledInvitationNameOption>
+  );
+};
+
+export default InvitationNameOption;
+
+const StyledInvitationNameOption = styled.div`
+  ${flex({ justifyContent: 'space-between', alignItems: 'flex-start' })}
+  padding: 28px 20px;
+  border-radius: 8px;
+  background: ${color.G0};
+`;

--- a/apps/web/src/components/form/NoticeOption/index.tsx
+++ b/apps/web/src/components/form/NoticeOption/index.tsx
@@ -1,0 +1,56 @@
+import { color } from '@merried/design-system';
+import { IconDragHandle } from '@merried/icon';
+import { Column, Input, Row, Text, ToggleButton } from '@merried/ui';
+import { flex } from '@merried/utils';
+import { styled } from 'styled-components';
+
+const NoticeOption = () => {
+  return (
+    <StyledNoticeOption>
+      <Column gap={28}>
+        <Column gap={8}>
+          <Row gap={8}>
+            <ToggleButton isOpen={false} />
+            <Text fontType="H3" color={color.G900}>
+              안내사항
+            </Text>
+          </Row>
+          <Text fontType="P3" color={color.G80}>
+            하객 분들에게 전하시고 싶은 공지나 안내사항을 적어주세요.
+          </Text>
+        </Column>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            제목
+          </Text>
+          <Input width={384} platform="DESKTOP" placeholder="제목을 입력해주세요" />
+        </Column>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            안내 문구<RequiredMark>*</RequiredMark>
+          </Text>
+          <Input width={384} platform="DESKTOP" placeholder="안내 문구를 입력해주세요" />
+        </Column>
+      </Column>
+      <IconDragHandle />
+    </StyledNoticeOption>
+  );
+};
+
+export default NoticeOption;
+
+const StyledNoticeOption = styled.div`
+  ${flex({ justifyContent: 'space-between', alignItems: 'flex-start' })}
+  padding: 28px 20px;
+  border-radius: 8px;
+  background: ${color.G0};
+`;
+
+const RequiredMark = styled.span`
+  color: ${color.red};
+  font-family: 'Pretendard Variable';
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 100%;
+`;

--- a/apps/web/src/components/form/VideoOption/index.tsx
+++ b/apps/web/src/components/form/VideoOption/index.tsx
@@ -1,0 +1,51 @@
+import { color } from '@merried/design-system';
+import { IconDragHandle } from '@merried/icon';
+import { Column, Input, Row, Text, ToggleButton } from '@merried/ui';
+import { flex } from '@merried/utils';
+import { styled } from 'styled-components';
+
+const VideoOption = () => {
+  return (
+    <StyledVideoOption>
+      <Column gap={28}>
+        <Row gap={8}>
+          <ToggleButton isOpen={false} />
+          <Text fontType="H3" color={color.G900}>
+            영상
+          </Text>
+        </Row>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            영상 제목
+          </Text>
+          <Input width={384} platform="DESKTOP" placeholder="제목을 입력해주세요" />
+        </Column>
+        <Column gap={8}>
+          <Text fontType="P3" color={color.G900}>
+            유튜브 URL<RequiredMark>*</RequiredMark>
+          </Text>
+          <Input width={384} platform="DESKTOP" placeholder="URL을 입력해주세요" />
+        </Column>
+      </Column>
+      <IconDragHandle />
+    </StyledVideoOption>
+  );
+};
+
+export default VideoOption;
+
+const StyledVideoOption = styled.div`
+  ${flex({ justifyContent: 'space-between', alignItems: 'flex-start' })}
+  padding: 28px 20px;
+  border-radius: 8px;
+  background: ${color.G0};
+`;
+
+const RequiredMark = styled.span`
+  color: ${color.red};
+  font-family: 'Pretendard Variable';
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 100%;
+`;


### PR DESCRIPTION
## 📄 Summary

> 청접장 만들기 옵션 중 단순 입력 관련 옵션 퍼블리싱했습니다.

<br>

## 🔨 Tasks

- 청접장 명 옵션 퍼블리싱[1]
- 초대 글귀 옵션 퍼블리싱[4]
- 영상 옵션 퍼블리싱[9]
- 안내사항 옵션 퍼블리싱[12]
- 방명록 옵션 퍼블리싱[13]
- 게스트 스냅 옵션 퍼블리싱[14]

<br>

## 🙋🏻 More
![image](https://github.com/user-attachments/assets/aac5bc6a-9e19-44e3-9a9d-e03342c3c754)
![image](https://github.com/user-attachments/assets/d09be1c3-a2c9-4222-8dbf-dcc2b280e448)

RequiredMark를 따로 스타일링한 이유는 해당 규격에 맞는 폰트가 없어서 따로 스타일링 하였습니다.
현재는 퍼블리싱 작업 중에 있어 따로 value 상태나 onChage는 적용하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 게스트북, 초대 메시지, 초대장 이름, 안내 문구, 영상, 게스트 스냅 옵션 등 다양한 입력 폼 컴포넌트가 추가되었습니다.
  - 각 컴포넌트는 토글 버튼, 제목, 필수 입력 표시, 입력란, 드래그 핸들 아이콘 등 사용자 친화적 UI 요소를 포함합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->