### PR TITLE
fix(mobile): interface에서 사용하는게 타입이 잘못되어서 수정

### DIFF
--- a/apps/mobile/src/components/my/ListItem/ListItem.tsx
+++ b/apps/mobile/src/components/my/ListItem/ListItem.tsx
@@ -2,11 +2,11 @@ import { color } from '@merried/design-system';
 import { IconArrow } from '@merried/icon';
 import { Row, Text } from '@merried/ui';
 import { flex } from '@merried/utils';
-import { SVGProps } from 'react';
+import { ComponentType } from 'react';
 import styled from 'styled-components';
 
 interface ListItemProps {
-  icon: React.ComponentType<SVGProps<SVGSVGElement>>;
+  icon: ComponentType<{ width: number; height: number }>;
   title: string;
 }
 


### PR DESCRIPTION
## 📄 Summary

> 리스트 아이템에서 사용하는 props의 타입이 잘못되어서 이를 수정했습니다.

<br>

## 🔨 Tasks

- props 타입 수정

<br>

## 🙋🏻 More
