### PR TITLE
feat(mobile): 청첩장 기본 정보 페이지 퍼블리싱

### DIFF
--- a/apps/mobile/src/app/invitation/[id]/page.tsx
+++ b/apps/mobile/src/app/invitation/[id]/page.tsx
@@ -1,10 +1,42 @@
 'use client';
 
+import CoupleInfo from '@/components/invitation/CoupleInfo/CoupleInfo';
+import Greeting from '@/components/invitation/Greeting/Greeting';
+import StartBackground from '@/components/invitation/StartBackground/StartBackground';
 import AppLayout from '@/layouts/AppLayout';
 import { color } from '@merried/design-system';
+import { Column, Text } from '@merried/ui';
+import { flex } from '@merried/utils';
+import styled from 'styled-components';
 
 const InvitationDetail = () => {
-  return <AppLayout backgroundColor={color.G0}>청첩장 미리보기 페이지</AppLayout>;
+  return (
+    <AppLayout backgroundColor={color.G0}>
+      <Column width="100%" alignItems="center">
+        <StartBackground man="JAEHO" woman="YUBIN" date="2025. 03. 20 SUN" />
+        <StyledInvitation>
+          <Greeting />
+          <CoupleInfo
+            coupleList={[
+              { father: '박OO', mother: '이OO', gender: 'SON', name: '박아들' },
+              { father: '최OO', mother: '이OO', gender: 'DAUGHTER', name: '최딸' },
+            ]}
+          />
+          <Text fontType="P4" color={color.G80}>
+            COPYRIGHT Kangwon Park. All rights reserved.
+          </Text>
+        </StyledInvitation>
+      </Column>
+    </AppLayout>
+  );
 };
 
 export default InvitationDetail;
+
+const StyledInvitation = styled.div`
+  ${flex({ flexDirection: 'column', alignItems: 'center' })}
+  width: 100%;
+  height: 100%;
+  padding: 32px 12px 100px;
+  gap: 100px;
+`;

--- a/apps/mobile/src/components/common/CustomText/CustomText.tsx
+++ b/apps/mobile/src/components/common/CustomText/CustomText.tsx
@@ -22,6 +22,7 @@ interface CustomTextProps {
   size: number;
   line: number;
   weight: number;
+  align?: string;
 }
 
 const CustomText = ({
@@ -31,6 +32,7 @@ const CustomText = ({
   size,
   line,
   weight,
+  align = 'center',
 }: CustomTextProps) => {
   return (
     <StyledCustomText
@@ -39,6 +41,7 @@ const CustomText = ({
       size={size}
       line={line}
       weight={weight}
+      align={align}
     >
       {children}
     </StyledCustomText>
@@ -53,11 +56,12 @@ const StyledCustomText = styled.div<{
   size: number;
   line: number;
   weight: number;
+  align: string;
 }>`
   font-family: ${(p) => p.font};
   font-size: ${(p) => p.size}px;
   font-weight: ${(p) => p.weight};
   line-height: ${(p) => p.line}%;
   color: ${(p) => p.color};
-  text-align: center;
+  text-align: ${(p) => p.align};
 `;

--- a/apps/mobile/src/components/common/CustomText/CustomText.tsx
+++ b/apps/mobile/src/components/common/CustomText/CustomText.tsx
@@ -22,7 +22,7 @@ interface CustomTextProps {
   size: number;
   line: number;
   weight: number;
-  align?: string;
+  align?: 'left' | 'right' | 'center' | 'justify';
 }
 
 const CustomText = ({
@@ -61,7 +61,7 @@ const StyledCustomText = styled.div<{
   font-family: ${(p) => p.font};
   font-size: ${(p) => p.size}px;
   font-weight: ${(p) => p.weight};
-  line-height: ${(p) => p.line}%;
+  line-height: ${(p) => p.line / 100};
   color: ${(p) => p.color};
   text-align: ${(p) => p.align};
 `;

--- a/apps/mobile/src/components/common/CustomText/CustomText.tsx
+++ b/apps/mobile/src/components/common/CustomText/CustomText.tsx
@@ -1,0 +1,63 @@
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+
+interface CustomTextProps {
+  children: ReactNode;
+  fontType:
+    | 'Ownglyph Kundo'
+    | 'Pretendard'
+    | 'YUniverse-B'
+    | 'BBB0003'
+    | 'Paperlogy'
+    | 'Diphylleia'
+    | 'DOSGothic'
+    | 'KoreanCNMM'
+    | 'LeeSeoyun'
+    | 'MapoDacapo'
+    | 'Ownglyph Baek Subin'
+    | 'Nelna Yesam'
+    | 'White Angelica'
+    | 'Heir of Light OTF';
+  color: string;
+  size: number;
+  line: number;
+  weight: number;
+}
+
+const CustomText = ({
+  fontType,
+  color,
+  children,
+  size,
+  line,
+  weight,
+}: CustomTextProps) => {
+  return (
+    <StyledCustomText
+      font={fontType}
+      color={color}
+      size={size}
+      line={line}
+      weight={weight}
+    >
+      {children}
+    </StyledCustomText>
+  );
+};
+
+export default CustomText;
+
+const StyledCustomText = styled.div<{
+  font: string;
+  color: string;
+  size: number;
+  line: number;
+  weight: number;
+}>`
+  font-family: ${(p) => p.font};
+  font-size: ${(p) => p.size}px;
+  font-weight: ${(p) => p.weight};
+  line-height: ${(p) => p.line}%;
+  color: ${(p) => p.color};
+  text-align: center;
+`;

--- a/apps/mobile/src/components/home/InvitationItem/InvitationItem.tsx
+++ b/apps/mobile/src/components/home/InvitationItem/InvitationItem.tsx
@@ -24,6 +24,10 @@ const InvitationItem = ({ id, title, date, hour }: InvitationItemProps) => {
     router.push(`${ROUTES.GUESTBOOK}/${id}`);
   };
 
+  const handleMoveInvitation = () => {
+    router.push(`${ROUTES.INVITATION}/${id}`);
+  };
+
   return (
     <StyledInvitationItem>
       <Background src="images/type01.svg" alt="초대장 배경" />
@@ -43,7 +47,11 @@ const InvitationItem = ({ id, title, date, hour }: InvitationItemProps) => {
           </Row>
         </Column>
         <Row alignItems="center" gap={8}>
-          <Badge icon={IconBoldLetter} title="청첩장 확인" onClick={() => {}} />
+          <Badge
+            icon={IconBoldLetter}
+            title="청첩장 확인"
+            onClick={handleMoveInvitation}
+          />
           <Badge icon={IconBoldShare} title="URL 복사" onClick={() => {}} />
           {weddingDate && (
             <Badge

--- a/apps/mobile/src/components/invitation/CoupleInfo/CoupleInfo.tsx
+++ b/apps/mobile/src/components/invitation/CoupleInfo/CoupleInfo.tsx
@@ -1,0 +1,36 @@
+import { flex } from '@merried/utils';
+import styled from 'styled-components';
+import CoupleInfoItem from './CoupleInfoItem/CoupleInfoItem';
+
+type CoupleInfoProps = {
+  coupleList: {
+    father: string;
+    mother: string;
+    gender: 'SON' | 'DAUGHTER';
+    name: string;
+  }[];
+};
+
+const CoupleInfo = ({ coupleList }: CoupleInfoProps) => {
+  return (
+    <StyledCoupleInfo>
+      {coupleList.map(({ father, mother, gender, name }, idx) => (
+        <CoupleInfoItem
+          key={idx}
+          father={father}
+          mother={mother}
+          gender={gender}
+          name={name}
+        />
+      ))}
+    </StyledCoupleInfo>
+  );
+};
+
+export default CoupleInfo;
+
+const StyledCoupleInfo = styled.div`
+  ${flex({ flexDirection: 'column', alignItems: 'center' })}
+  width: 100%;
+  gap: 12px;
+`;

--- a/apps/mobile/src/components/invitation/CoupleInfo/CoupleInfoItem/CoupleInfoItem.tsx
+++ b/apps/mobile/src/components/invitation/CoupleInfo/CoupleInfoItem/CoupleInfoItem.tsx
@@ -1,0 +1,45 @@
+import CustomText from '@/components/common/CustomText/CustomText';
+import { GENDER_MAP } from '@/constants/invitation/constants';
+import { color } from '@merried/design-system';
+import { flex } from '@merried/utils';
+import styled from 'styled-components';
+
+interface CoupleInfoItme {
+  mother: string;
+  father: string;
+  gender: 'SON' | 'DAUGHTER';
+  name: string;
+}
+
+const CoupleInfoItem = ({ mother, father, gender, name }: CoupleInfoItme) => {
+  return (
+    <StyledCoupleInfoItem>
+      <CustomText
+        fontType="Ownglyph Kundo"
+        color={color.G900}
+        size={20}
+        weight={400}
+        line={100}
+      >
+        {father} • {mother}의 {GENDER_MAP[gender]}
+      </CustomText>
+      <CustomText
+        fontType="Ownglyph Kundo"
+        color={color.pointYellow}
+        size={20}
+        weight={400}
+        line={100}
+      >
+        {name}
+      </CustomText>
+    </StyledCoupleInfoItem>
+  );
+};
+
+export default CoupleInfoItem;
+
+const StyledCoupleInfoItem = styled.div`
+  ${flex({ flexDirection: 'row', alignItems: 'center', justifyContent: 'center' })}
+  width: 100%;
+  gap: 12px;
+`;

--- a/apps/mobile/src/components/invitation/Greeting/Greeting.tsx
+++ b/apps/mobile/src/components/invitation/Greeting/Greeting.tsx
@@ -1,0 +1,55 @@
+import CustomText from '@/components/common/CustomText/CustomText';
+import { color } from '@merried/design-system';
+import { Column } from '@merried/ui';
+import { flex } from '@merried/utils';
+import styled from 'styled-components';
+
+const Greeting = () => {
+  return (
+    <StyledGreeting>
+      <CustomText
+        fontType="YUniverse-B"
+        color={color.pointYellow}
+        size={32}
+        weight={700}
+        line={100}
+      >
+        븿
+      </CustomText>
+      <Column gap={16} alignItems="center">
+        <CustomText
+          fontType="Ownglyph Kundo"
+          color={color.pointYellow}
+          size={24}
+          weight={400}
+          line={100}
+        >
+          소중한 여러분을 초대합니다
+        </CustomText>
+        <CustomText
+          fontType="Ownglyph Kundo"
+          color={color.G900}
+          size={18}
+          weight={400}
+          line={140}
+        >
+          오랜 기다림 속에서 저희 두 사람,
+          <br />한 마음 되어 참된 사랑의 결실을
+          <br />
+          맺게 되었습니다.
+          <br />
+          <br />
+          오셔서 축복해 주시면 큰 기쁨이겠습니다.
+        </CustomText>
+      </Column>
+    </StyledGreeting>
+  );
+};
+
+export default Greeting;
+
+const StyledGreeting = styled.div`
+  ${flex({ flexDirection: 'column', alignItems: 'center' })}
+  width: 100%;
+  gap: 32px;
+`;

--- a/apps/mobile/src/components/invitation/StartBackground/StartBackground.tsx
+++ b/apps/mobile/src/components/invitation/StartBackground/StartBackground.tsx
@@ -1,0 +1,68 @@
+import { color, getTemplateFontStyle } from '@merried/design-system';
+import { IconShortArrow } from '@merried/icon';
+import { Column, Row } from '@merried/ui';
+import { flex } from '@merried/utils';
+import { styled } from 'styled-components';
+
+interface StartBackgroundProps {
+  man: string;
+  woman: string;
+  date: string;
+}
+
+const StartBackground = ({ man, woman, date }: StartBackgroundProps) => {
+  return (
+    <StyledStartBackground>
+      <Row width="100%" alignItems="center" justifyContent="space-between">
+        <TopTitle>{man}</TopTitle>
+        <TopTitle>{date}</TopTitle>
+        <TopTitle>{woman}</TopTitle>
+      </Row>
+      <Column gap={15} alignItems="center">
+        <BottomTitle>
+          THE START OF
+          <br />
+          OUR FOREVER
+        </BottomTitle>
+        <Circle>
+          <IconShortArrow width={16} height={16} />
+        </Circle>
+      </Column>
+    </StyledStartBackground>
+  );
+};
+
+export default StartBackground;
+
+const StyledStartBackground = styled.div`
+  ${flex({
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  })}
+  width: 100%;
+  height: 100vh;
+  background: url('/guestbook.png') center/cover no-repeat;
+  padding: 54px 22px 24px;
+`;
+
+const TopTitle = styled.div`
+  ${getTemplateFontStyle('template1')}
+  color: ${color.G0};
+`;
+
+const BottomTitle = styled.div`
+  ${getTemplateFontStyle('template1', 'BBB0003')}
+  color: ${color.letterYellow};
+  text-align: center;
+`;
+
+const Circle = styled.div`
+  ${flex({ alignItems: 'center', justifyContent: 'center' })}
+  width: 44px;
+  height: 44px;
+  border-radius: 99px;
+  border: 1px solid rgba(255, 255, 255, 0.26);
+  background: rgba(255, 255, 255, 0.21);
+  backdrop-filter: blur(14.699999809265137px);
+`;

--- a/apps/mobile/src/components/invitation/StartBackground/StartBackground.tsx
+++ b/apps/mobile/src/components/invitation/StartBackground/StartBackground.tsx
@@ -1,4 +1,5 @@
-import { color, getTemplateFontStyle } from '@merried/design-system';
+import CustomText from '@/components/common/CustomText/CustomText';
+import { color } from '@merried/design-system';
 import { IconShortArrow } from '@merried/icon';
 import { Column, Row } from '@merried/ui';
 import { flex } from '@merried/utils';
@@ -14,16 +15,46 @@ const StartBackground = ({ man, woman, date }: StartBackgroundProps) => {
   return (
     <StyledStartBackground>
       <Row width="100%" alignItems="center" justifyContent="space-between">
-        <TopTitle>{man}</TopTitle>
-        <TopTitle>{date}</TopTitle>
-        <TopTitle>{woman}</TopTitle>
+        <CustomText
+          fontType="Heir of Light OTF"
+          color={color.G0}
+          size={16}
+          weight={400}
+          line={100}
+        >
+          {man}
+        </CustomText>
+        <CustomText
+          fontType="Heir of Light OTF"
+          color={color.G0}
+          size={16}
+          weight={400}
+          line={100}
+        >
+          {date}
+        </CustomText>
+        <CustomText
+          fontType="Heir of Light OTF"
+          color={color.G0}
+          size={16}
+          weight={400}
+          line={100}
+        >
+          {woman}
+        </CustomText>
       </Row>
       <Column gap={15} alignItems="center">
-        <BottomTitle>
+        <CustomText
+          fontType="BBB0003"
+          color={color.letterYellow}
+          size={44}
+          weight={700}
+          line={110}
+        >
           THE START OF
           <br />
           OUR FOREVER
-        </BottomTitle>
+        </CustomText>
         <Circle>
           <IconShortArrow width={16} height={16} />
         </Circle>
@@ -42,19 +73,10 @@ const StyledStartBackground = styled.div`
   })}
   width: 100%;
   height: 100vh;
-  background: url('/guestbook.png') center/cover no-repeat;
+  background:
+    url('/guestbook.png') center/cover no-repeat,
+    ${color.G100};
   padding: 54px 22px 24px;
-`;
-
-const TopTitle = styled.div`
-  ${getTemplateFontStyle('template1')}
-  color: ${color.G0};
-`;
-
-const BottomTitle = styled.div`
-  ${getTemplateFontStyle('template1', 'BBB0003')}
-  color: ${color.letterYellow};
-  text-align: center;
 `;
 
 const Circle = styled.div`

--- a/apps/mobile/src/constants/invitation/constants.ts
+++ b/apps/mobile/src/constants/invitation/constants.ts
@@ -1,0 +1,4 @@
+export const GENDER_MAP = {
+  SON: '아들',
+  DAUGHTER: '딸',
+} as const;

--- a/packages/design-system/src/global.ts
+++ b/packages/design-system/src/global.ts
@@ -93,6 +93,13 @@ const GlobalStyle = createGlobalStyle`
   font-display: swap;
 }
 
+@font-face {
+  font-family: 'YUniverse-B';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_yuniverse@1.0/YUniverse-B.woff2') format('woff2');
+  font-weight: normal;
+  font-style: normal;
+}
+
 * {
   box-sizing: border-box;
   margin: 0;

--- a/packages/design-system/src/global.ts
+++ b/packages/design-system/src/global.ts
@@ -98,6 +98,7 @@ const GlobalStyle = createGlobalStyle`
   src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_yuniverse@1.0/YUniverse-B.woff2') format('woff2');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 * {

--- a/packages/icon/index.ts
+++ b/packages/icon/index.ts
@@ -20,4 +20,5 @@ export { default as IconMegaphone } from './src/IconMegaphone';
 export { default as IconDragHandle } from './src/IconDragHandle';
 export { default as IconCheck } from './src/IconCheck';
 export { default as IconBoldList } from './src/IconBoldList';
-export { default as IconCalendar } from './src/IconCalendar'
+export { default as IconCalendar } from './src/IconCalendar';
+export { default as IconShortArrow } from './src/IconShortArrow';

--- a/packages/icon/src/IconShortArrow.tsx
+++ b/packages/icon/src/IconShortArrow.tsx
@@ -1,0 +1,26 @@
+import type { SVGProps } from 'react';
+import React from 'react';
+
+const IconShortArrow = (props: SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <g clipPath="url(#clip0_278_1837)">
+      <path
+        d="M4 10.667L8 14.667L12 10.667"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="square"
+      />
+      <path
+        d="M7 14.6673C7 15.2196 7.44771 15.6673 8 15.6673C8.55228 15.6673 9 15.2196 9 14.6673L7 14.6673ZM9 1.33398L9 0.333984L7 0.333984L7 1.33398L9 1.33398ZM9 14.6673L9 1.33398L7 1.33398L7 14.6673L9 14.6673Z"
+        fill="white"
+      />
+    </g>
+    <defs>
+      <clipPath id="clip0_278_1837">
+        <rect width="16" height="16" fill="white" transform="translate(16) rotate(90)" />
+      </clipPath>
+    </defs>
+  </svg>
+);
+
+export default IconShortArrow;


### PR DESCRIPTION
## 📄 Summary

> 청첩장에서 기본적으로 포함 내용을 답고 있는 부분을 퍼블리싱을 진행했습니다.

<br>

## 🔨 Tasks

- 시작 페이지 사진 컴포넌트 개발
- 화살표 아이콘 컴포넌트 추가
- 인사말, 커플 정보 컴포넌트 개발

<br>

## 🙋🏻 More

https://github.com/user-attachments/assets/fc2993f1-c6d4-4ba0-b0a5-90d79f54191c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 모바일 앱에 초대장 상세 미리보기 화면이 추가되었습니다.
  - 초대장 화면에 배경(StartBackground), 인사말(Greeting), 신랑·신부 및 부모 정보(CoupleInfo, CoupleInfoItem), 커스텀 텍스트(CustomText) 컴포넌트가 도입되었습니다.
  - 홈 초대장 항목에서 초대장 상세 페이지로 이동하는 내비게이션 기능이 활성화되었습니다.
  - 새로운 아이콘(짧은 화살표 IconShortArrow)과 폰트(YUniverse-B)가 추가되었습니다.

- **디자인 및 스타일**
  - 초대장 화면 및 텍스트에 다양한 폰트와 색상이 적용되어 시각적 완성도가 향상되었습니다.

- **기타**
  - 초대장에서 성별 표기를 위한 상수(GENDER_MAP)가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->