### PR TITLE
feat(mobile): 참석 여부 바텀 시트 컴포넌트 퍼블리싱

### DIFF
--- a/apps/mobile/src/components/common/BottomSheet/BottomSheet.tsx
+++ b/apps/mobile/src/components/common/BottomSheet/BottomSheet.tsx
@@ -1,7 +1,9 @@
-import React, { useState, useRef, useEffect, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import { color } from '@merried/design-system';
 import { flex } from '@merried/utils';
 import styled from 'styled-components';
+import useBodyScrollLock from '@/hooks/useBodyScrollLock';
+import useSwipeDown from '@/hooks/useSwipeDown';
 
 interface BottomSheetProps {
   isOpen: boolean;
@@ -9,36 +11,9 @@ interface BottomSheetProps {
   children: ReactNode;
 }
 
-const SWIPE_THRESHOLD = 120;
-
 const BottomSheet = ({ isOpen, onClose, children }: BottomSheetProps) => {
-  const [dragY, setDragY] = useState(0);
-  const [dragging, setDragging] = useState(false);
-  const startYRef = useRef(0);
-
-  useEffect(() => {
-    if (isOpen) setDragY(0);
-  }, [isOpen]);
-
-  const handlePointerDown = (e: React.PointerEvent) => {
-    startYRef.current = e.clientY;
-    setDragging(true);
-  };
-
-  const handlePointerMove = (e: React.PointerEvent) => {
-    if (!dragging) return;
-    const delta = e.clientY - startYRef.current;
-    if (delta > 0) setDragY(delta);
-  };
-
-  const handlePointerUp = () => {
-    setDragging(false);
-    if (dragY > SWIPE_THRESHOLD) {
-      onClose();
-    } else {
-      setDragY(0);
-    }
-  };
+  useBodyScrollLock(isOpen);
+  const { dragY, dragging, handlers } = useSwipeDown(isOpen, onClose);
 
   return (
     <Background $isOpen={isOpen}>
@@ -46,9 +21,7 @@ const BottomSheet = ({ isOpen, onClose, children }: BottomSheetProps) => {
         $isOpen={isOpen}
         $dragY={dragY}
         $dragging={dragging}
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
+        {...handlers}
         onClick={(e) => e.stopPropagation()}
       >
         <Line />
@@ -66,7 +39,6 @@ const Background = styled.div<{ $isOpen: boolean }>`
   display: flex;
   align-items: flex-end;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.3);
   pointer-events: ${(p) => (p.$isOpen ? 'auto' : 'none')};
   opacity: ${(p) => (p.$isOpen ? 1 : 0)};
   transition: opacity 0.3s ease;
@@ -80,13 +52,16 @@ const StyledBottomSheet = styled.div<{
 }>`
   ${flex({ flexDirection: 'column', alignItems: 'center', justifyContent: 'flex-start' })}
   width: 100%;
-  height: 439px;
+  height: auto;
   background-color: ${color.G0};
   border-radius: 24px 24px 0 0;
   padding: 24px 12px 49px;
   touch-action: none;
   transform: ${(p) => (p.$isOpen ? `translateY(${p.$dragY}px)` : 'translateY(100%)')};
   transition: ${(p) => (p.$dragging ? 'none' : 'transform 0.3s ease-out')};
+  box-shadow:
+    -5px -15px 9px 0px rgba(199, 199, 199, 0.05),
+    -2px -7px 7px 0px rgba(199, 199, 199, 0.09);
 `;
 
 const Line = styled.div`

--- a/apps/mobile/src/components/common/ButtonGroup/ButtonGroup.tsx
+++ b/apps/mobile/src/components/common/ButtonGroup/ButtonGroup.tsx
@@ -10,25 +10,30 @@ interface ButtonItem {
 }
 
 interface ButtonGroupProps {
-  title: string;
+  title?: string;
   buttons: ButtonItem[];
+  pointColor?: string;
 }
 
-const ButtonGroup = ({ title, buttons }: ButtonGroupProps) => {
+const ButtonGroup = ({ title, buttons, pointColor }: ButtonGroupProps) => {
   const [selectedButton, setSelectedButton] = useState<number>(0);
 
   return (
     <StyledButtonGroup>
-      <Text fontType="P2" color={color.G900}>
-        {title}
-      </Text>
+      {title && (
+        <Text fontType="P2" color={color.G900}>
+          {title}
+        </Text>
+      )}
       <Row alignItems="center" gap={19} width="100%">
         {buttons.map((button, index) => (
           <Button
             key={index}
-            styleType={selectedButton === index ? 'DEFAULT' : 'SELECT'}
-            size='SMALL'
+            styleType={selectedButton === index ? 'DEFAULT' : 'SECOND'}
+            pointColor={pointColor}
+            size="SMALL"
             width="100%"
+            style={{ flex: 1, minWidth: 0 }}
             onClick={() => {
               setSelectedButton(index);
               button.onClick();

--- a/apps/mobile/src/components/common/ButtonGroup/DesktopButtonGroup.tsx
+++ b/apps/mobile/src/components/common/ButtonGroup/DesktopButtonGroup.tsx
@@ -1,0 +1,56 @@
+import { color } from '@merried/design-system';
+import { DesktopButton, Row, Text } from '@merried/ui';
+import { flex } from '@merried/utils';
+import { useState } from 'react';
+import styled from 'styled-components';
+
+interface ButtonItem {
+  label: string;
+  onClick: () => void;
+}
+
+interface DesktopButtonGroupProps {
+  title?: string;
+  buttons: ButtonItem[];
+  pointColor?: string;
+}
+
+const DesktopButtonGroup = ({ title, buttons, pointColor }: DesktopButtonGroupProps) => {
+  const [selectedButton, setSelectedButton] = useState<number>(0);
+
+  return (
+    <StyledButtonGroup>
+      {title && (
+        <Text fontType="P3" color={color.G900}>
+          {title}
+        </Text>
+      )}
+      <Row alignItems="center" gap={19} width="100%">
+        {buttons.map((button, index) => (
+          <DesktopButton
+            key={index}
+            styleType={selectedButton === index ? 'DEFAULT' : 'SECOND'}
+            pointColor={pointColor}
+            size="SMALL"
+            width="100%"
+            style={{ flex: 1, minWidth: 0 }}
+            onClick={() => {
+              setSelectedButton(index);
+              button.onClick();
+            }}
+          >
+            <Text fontType="Button3" color={color.G900}>{button.label}</Text>
+          </DesktopButton>
+        ))}
+      </Row>
+    </StyledButtonGroup>
+  );
+};
+
+export default DesktopButtonGroup;
+
+const StyledButtonGroup = styled.div`
+  ${flex({ flexDirection: 'column', alignItems: 'flex-start' })}
+  width: 100%;
+  gap: 10px;
+`;

--- a/apps/mobile/src/components/invitation/AttendBottomSheet/AttendBottomSheet.hooks.ts
+++ b/apps/mobile/src/components/invitation/AttendBottomSheet/AttendBottomSheet.hooks.ts
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+
+export const useInput = () => {
+  const [count, setCount] = useState('1');
+
+  const handleCountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value;
+    // 빈값 허용, 아니면 숫자만 허용
+    if (raw === '' || /^\d+$/.test(raw)) {
+      setCount(raw);
+    }
+  };
+
+  const handleCountBlur = () => {
+    // blur 시 빈값이거나 1 미만이면 1로 복구
+    const num = parseInt(count, 10);
+    if (isNaN(num) || num < 1) {
+      setCount('1');
+    }
+  };
+
+  return { handleCountChange, handleCountBlur, count };
+};

--- a/apps/mobile/src/components/invitation/AttendBottomSheet/AttendBottomSheet.tsx
+++ b/apps/mobile/src/components/invitation/AttendBottomSheet/AttendBottomSheet.tsx
@@ -1,0 +1,77 @@
+import BottomSheet from '@/components/common/BottomSheet/BottomSheet';
+import ButtonGroup from '@/components/common/ButtonGroup/ButtonGroup';
+import DesktopButtonGroup from '@/components/common/ButtonGroup/DesktopButtonGroup';
+import { color } from '@merried/design-system';
+import { Button, Column, Input, Text } from '@merried/ui';
+import { flex } from '@merried/utils';
+import { styled } from 'styled-components';
+
+interface AttendBottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const AttendBottomSheet = ({ isOpen, onClose }: AttendBottomSheetProps) => {
+  return (
+    <BottomSheet isOpen={isOpen} onClose={onClose}>
+      <StyledAttendBottomSheet>
+        <Column gap={40}>
+          <Column gap={24}>
+            <Column>
+              <Text fontType="H2" color={color.G900}>
+                결혼식 참석 의사
+              </Text>
+              <Text fontType="P2" color={color.G80}>
+                솔직한 답은 신랑•신부에게 도움이 됩니다
+              </Text>
+            </Column>
+            <ButtonGroup
+              buttons={[
+                { label: '신랑측', onClick: () => {} },
+                { label: '신부측', onClick: () => {} },
+              ]}
+              pointColor={color.pointYellow}
+            />
+            <Column gap={18}>
+              <Input
+                label="이름"
+                placeholder="이름을 입력해주세요"
+                size="LARGE"
+                width="100%"
+                onChange={() => {}}
+              />
+              <Input label="참석인원" size="LARGE" onChange={() => {}} />
+              <DesktopButtonGroup
+                title="식사 여부"
+                buttons={[
+                  { label: '예정', onClick: () => {} },
+                  { label: '안함', onClick: () => {} },
+                  { label: '미정', onClick: () => {} },
+                ]}
+                pointColor={color.pointYellow}
+              />
+            </Column>
+          </Column>
+          <Button
+            size="VERY_LARGE"
+            onClick={() => {}}
+            pointColor={color.pointYellow}
+            width="100%"
+          >
+            <Text fontType="Button3" color={color.G900}>
+              참석 의사 전달하기
+            </Text>
+          </Button>
+        </Column>
+      </StyledAttendBottomSheet>
+    </BottomSheet>
+  );
+};
+
+export default AttendBottomSheet;
+
+const StyledAttendBottomSheet = styled.div`
+  ${flex({ flexDirection: 'column', alignItems: 'stretch' })}
+  width: 100%;
+  margin-top: 40px;
+`;

--- a/apps/mobile/src/components/invitation/AttendBottomSheet/AttendBottomSheet.tsx
+++ b/apps/mobile/src/components/invitation/AttendBottomSheet/AttendBottomSheet.tsx
@@ -5,6 +5,7 @@ import { color } from '@merried/design-system';
 import { Button, Column, Input, Text } from '@merried/ui';
 import { flex } from '@merried/utils';
 import { styled } from 'styled-components';
+import { useInput } from './AttendBottomSheet.hooks';
 
 interface AttendBottomSheetProps {
   isOpen: boolean;
@@ -12,6 +13,8 @@ interface AttendBottomSheetProps {
 }
 
 const AttendBottomSheet = ({ isOpen, onClose }: AttendBottomSheetProps) => {
+  const { handleCountChange, handleCountBlur, count } = useInput();
+
   return (
     <BottomSheet isOpen={isOpen} onClose={onClose}>
       <StyledAttendBottomSheet>
@@ -40,7 +43,18 @@ const AttendBottomSheet = ({ isOpen, onClose }: AttendBottomSheetProps) => {
                 width="100%"
                 onChange={() => {}}
               />
-              <Input label="참석인원" size="LARGE" onChange={() => {}} />
+              <Input
+                label="참석인원"
+                size="LARGE"
+                type="number"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                min={1}
+                step={1}
+                value={count}
+                onChange={handleCountChange}
+                onBlur={handleCountBlur}
+              />
               <DesktopButtonGroup
                 title="식사 여부"
                 buttons={[

--- a/apps/mobile/src/components/invitation/AttendFloatButton/AttendFloatButton.tsx
+++ b/apps/mobile/src/components/invitation/AttendFloatButton/AttendFloatButton.tsx
@@ -1,11 +1,21 @@
 import { color } from '@merried/design-system';
 import { Text } from '@merried/ui';
 import { flex } from '@merried/utils';
+import { useOverlay } from '@toss/use-overlay';
 import styled from 'styled-components';
+import AttendBottomSheet from '../AttendBottomSheet/AttendBottomSheet';
 
 const AttendFloatButton = () => {
+  const overlay = useOverlay();
+
+  const handleOpenBottomSheet = () => {
+    overlay.open(({ isOpen, close }) => (
+      <AttendBottomSheet isOpen={isOpen} onClose={close} />
+    ));
+  };
+
   return (
-    <StyledAttendFloatButton onClick={() => {}}>
+    <StyledAttendFloatButton onClick={handleOpenBottomSheet}>
       <ActionButton>
         <Text fontType="Button3" color={color.G900}>
           참석 의사 전달하기

--- a/apps/mobile/src/components/shop/GiftPickerBottomSheet/GiftPickerBottomSheet.tsx
+++ b/apps/mobile/src/components/shop/GiftPickerBottomSheet/GiftPickerBottomSheet.tsx
@@ -54,6 +54,6 @@ const StyledGiftPickerBottomSheet = styled.div`
     alignItems: 'flex-start',
   })}
   width: 100%;
-  margin-top: 32px;
+  margin-top: 36px;
   gap: 56px;
 `;

--- a/apps/mobile/src/hooks/useBodyScrollLock.ts
+++ b/apps/mobile/src/hooks/useBodyScrollLock.ts
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+
+export default function useBodyScrollLock(lock: boolean) {
+  useEffect(() => {
+    document.body.style.overflow = lock ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [lock]);
+}

--- a/apps/mobile/src/hooks/useSwipeDown.ts
+++ b/apps/mobile/src/hooks/useSwipeDown.ts
@@ -4,6 +4,7 @@ interface SwipeHandlers {
   onPointerDown: React.PointerEventHandler;
   onPointerMove: React.PointerEventHandler;
   onPointerUp: React.PointerEventHandler;
+  onPointerLeave: React.PointerEventHandler;
 }
 
 export default function useSwipeDown(
@@ -23,16 +24,27 @@ export default function useSwipeDown(
     startY.current = e.clientY;
     setDragging(true);
   };
+
   const onPointerMove: SwipeHandlers['onPointerMove'] = (e) => {
     if (!dragging) return;
     const delta = e.clientY - startY.current;
     if (delta > 0) setDragY(delta);
   };
+
   const onPointerUp: SwipeHandlers['onPointerUp'] = () => {
     setDragging(false);
     if (dragY > threshold) onClose();
     else setDragY(0);
   };
 
-  return { dragY, dragging, handlers: { onPointerDown, onPointerMove, onPointerUp } };
+  const onPointerLeave: SwipeHandlers['onPointerLeave'] = () => {
+    setDragging(false);
+    setDragY(0);
+  };
+
+  return {
+    dragY,
+    dragging,
+    handlers: { onPointerDown, onPointerMove, onPointerUp, onPointerLeave },
+  };
 }

--- a/apps/mobile/src/hooks/useSwipeDown.ts
+++ b/apps/mobile/src/hooks/useSwipeDown.ts
@@ -1,0 +1,38 @@
+import { useState, useRef, useEffect } from 'react';
+
+interface SwipeHandlers {
+  onPointerDown: React.PointerEventHandler;
+  onPointerMove: React.PointerEventHandler;
+  onPointerUp: React.PointerEventHandler;
+}
+
+export default function useSwipeDown(
+  isOpen: boolean,
+  onClose: () => void,
+  threshold = 120
+): { dragY: number; dragging: boolean; handlers: SwipeHandlers } {
+  const startY = useRef(0);
+  const [dragY, setDragY] = useState(0);
+  const [dragging, setDragging] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) setDragY(0);
+  }, [isOpen]);
+
+  const onPointerDown: SwipeHandlers['onPointerDown'] = (e) => {
+    startY.current = e.clientY;
+    setDragging(true);
+  };
+  const onPointerMove: SwipeHandlers['onPointerMove'] = (e) => {
+    if (!dragging) return;
+    const delta = e.clientY - startY.current;
+    if (delta > 0) setDragY(delta);
+  };
+  const onPointerUp: SwipeHandlers['onPointerUp'] = () => {
+    setDragging(false);
+    if (dragY > threshold) onClose();
+    else setDragY(0);
+  };
+
+  return { dragY, dragging, handlers: { onPointerDown, onPointerMove, onPointerUp } };
+}

--- a/packages/ui/src/Button/Button.tsx
+++ b/packages/ui/src/Button/Button.tsx
@@ -46,6 +46,7 @@ const StyledButton = styled.button<{
   ${flex({ alignItems: 'center', justifyContent: 'center' })}
   border-radius: 8px;
   word-break: keep-all;
+  box-sizing: border-box;
 
   ${(props) => props && getButtonStyle[props.styleType]};
   ${(props) => props && getButtonSize[props.size]};

--- a/packages/ui/src/Button/DesktopButton.tsx
+++ b/packages/ui/src/Button/DesktopButton.tsx
@@ -2,13 +2,14 @@ import { ButtonHTMLAttributes, ReactNode, CSSProperties } from 'react';
 import { ButtonStyleType, DesktopButtonSize } from './button.type';
 import styled from 'styled-components';
 import { flex } from '@merried/utils';
-import { getDesktopButtonSize, getButtonStyle } from './button.style';
+import { getDesktopButtonSize, getButtonStyle, getPointColorStyle } from './button.style';
 
 type Props = {
   children: ReactNode;
   styleType?: ButtonStyleType;
   size?: DesktopButtonSize;
   width?: CSSProperties['width'];
+  pointColor?: string;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 const DesktopButton = ({
@@ -19,6 +20,7 @@ const DesktopButton = ({
   width,
   style,
   disabled,
+  pointColor,
 }: Props) => {
   return (
     <StyledDesktopButton
@@ -26,6 +28,7 @@ const DesktopButton = ({
       onClick={onClick}
       $styleType={styleType}
       $size={size}
+      pointColor={pointColor}
       disabled={disabled || styleType === 'DISABLED'}
     >
       {children}
@@ -38,6 +41,7 @@ export default DesktopButton;
 const StyledDesktopButton = styled.button<{
   $styleType: ButtonStyleType;
   $size: DesktopButtonSize;
+  pointColor?: string;
 }>`
   ${flex({ alignItems: 'center', justifyContent: 'center' })}
   border-radius: 8px;
@@ -45,4 +49,7 @@ const StyledDesktopButton = styled.button<{
 
   ${(props) => props && getButtonStyle[props.$styleType]};
   ${(props) => props && getDesktopButtonSize[props.$size]};
+
+  ${({ $styleType, pointColor }) =>
+    $styleType === 'DEFAULT' && getPointColorStyle(pointColor)}
 `;

--- a/packages/ui/src/Input/Input.tsx
+++ b/packages/ui/src/Input/Input.tsx
@@ -73,6 +73,7 @@ const StyledInput = styled.input<{
   background: ${color.G0};
 
   &::placeholder {
+    ${font.P3}
     color: ${color.G80};
   }
 


### PR DESCRIPTION
## 📄 Summary

> 참석 여부 바텀 시트 컴포넌트를 퍼블리싱했습니다.

<br>

## 🔨 Tasks

- 컴포넌트 개발
- 스크롤 방지, 스와이프로 닫기 훅 개발
- 추가 반응형을 위한 스타일 수정

<br>

## 🙋🏻 More
<img width="388" alt="스크린샷 2025-05-16 오전 8 55 30" src="https://github.com/user-attachments/assets/3c8638e0-f812-41a5-9786-df2a23ddc7b9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 데스크톱 환경에서 버튼 그룹을 표시하는 DesktopButtonGroup 컴포넌트가 추가되었습니다.
    - 하단 시트에서 참석 의사를 입력할 수 있는 AttendBottomSheet 컴포넌트가 추가되었습니다.
    - AttendFloatButton 클릭 시 참석 의사 입력 하단 시트가 오버레이로 표시됩니다.
    - 스와이프 다운 제스처 및 스크롤 잠금 기능을 위한 커스텀 훅(useSwipeDown, useBodyScrollLock)이 도입되었습니다.
    - 숫자 입력 관리를 위한 useInput 훅이 추가되었습니다.

- **기능 개선**
    - BottomSheet의 드래그 및 스와이프 동작이 개선되고, 시트 높이가 동적으로 변경되며, 시각적 효과(박스 섀도우)가 추가되었습니다.
    - ButtonGroup에서 제목(title)과 pointColor가 선택적으로 적용되고, 버튼 스타일 및 레이아웃이 개선되었습니다.
    - DesktopButton에 pointColor 속성이 추가되어 강조 색상 지정이 가능합니다.

- **스타일**
    - GiftPickerBottomSheet의 상단 마진이 소폭 조정되었습니다.
    - 버튼(box-sizing)이 border-box로 변경되어 레이아웃이 일관되게 표시됩니다.
    - Input 컴포넌트의 플레이스홀더 텍스트 스타일이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->