### PR TITLE
feat(#105): 로그인 API 연동 작업

### DIFF
--- a/apps/mobile/src/apis/storage/cookie.ts
+++ b/apps/mobile/src/apis/storage/cookie.ts
@@ -10,13 +10,13 @@ export class Cookie {
   static setItem(key: string, value: string) {
     if (typeof window === 'undefined') return;
 
-    cookie.set(key, value);
+    cookie.set(key, value, { path: '/' });
   }
 
   static removeItem(key: string) {
     if (typeof window === 'undefined') return;
 
-    cookie.remove(key);
+    cookie.remove(key, { path: '/' });
   }
 
   static removeAll() {

--- a/apps/mobile/src/apis/storage/cookie.ts
+++ b/apps/mobile/src/apis/storage/cookie.ts
@@ -18,4 +18,12 @@ export class Cookie {
 
     cookie.remove(key);
   }
+
+  static removeAll() {
+    if (typeof window === 'undefined') return;
+
+    Object.keys(cookie.getAll()).forEach((key) => {
+      cookie.remove(key, { path: '/' });
+    });
+  }
 }

--- a/apps/mobile/src/app/callback/kakao/page.tsx
+++ b/apps/mobile/src/app/callback/kakao/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useLoginMutation } from '@/services/auth/mutations';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+
+const CallbackKakao = () => {
+  const searchParams = useSearchParams();
+  const { loginMutate } = useLoginMutation();
+  const alreadyRun = useRef(false);
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+    if (code && !alreadyRun.current) {
+      alreadyRun.current = true;
+      loginMutate({ code, provider: 'KAKAO' });
+    }
+  }, [searchParams, loginMutate]);
+
+  return <></>;
+};
+
+export default CallbackKakao;

--- a/apps/mobile/src/app/callback/naver/page.tsx
+++ b/apps/mobile/src/app/callback/naver/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useLoginMutation } from '@/services/auth/mutations';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+
+const CallbackNaver = () => {
+  const searchParams = useSearchParams();
+  const { loginMutate } = useLoginMutation();
+  const alreadyRun = useRef(false);
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+    if (code && !alreadyRun.current) {
+      alreadyRun.current = true;
+      loginMutate({ code, provider: 'NAVER' });
+    }
+  }, [searchParams, loginMutate]);
+
+  return <></>;
+};
+
+export default CallbackNaver;

--- a/apps/mobile/src/app/page.tsx
+++ b/apps/mobile/src/app/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ROUTES } from '@/constants/common/constant';
 import AppLayout from '@/layouts/AppLayout';
 import { getTemplateFontStyle } from '@merried/design-system';
 import { Column, LoginButton } from '@merried/ui';
@@ -10,19 +9,32 @@ import styled from 'styled-components';
 
 const Login = () => {
   const router = useRouter();
+  const kakao = process.env.NEXT_PUBLIC_KAKAO_LOGIN_URL;
+  const naver = process.env.NEXT_PUBLIC_NAVER_LOGIN_URL;
+
+  const handleNaverLogin = () => {
+    if (naver) {
+      router.push(naver);
+    } else {
+      alert('네이버 로그인 URL이 설정되어 있지 않습니다.');
+    }
+  };
+
+  const handleKakaoLogin = () => {
+    if (kakao) {
+      router.push(kakao);
+    } else {
+      alert('카카오 로그인 URL이 설정되어 있지 않습니다.');
+    }
+  };
 
   return (
     <AppLayout>
       <StyledLogin>
         <Text>우리 결혼할래요?</Text>
         <Column alignItems="center" width="100%" gap={12}>
-          <LoginButton
-            type="KAKAO"
-            onClick={() => {
-              router.push(ROUTES.HOME);
-            }}
-          />
-          <LoginButton type="NAVER" onClick={() => {}} />
+          <LoginButton type="KAKAO" onClick={handleKakaoLogin} />
+          <LoginButton type="NAVER" onClick={handleNaverLogin} />
         </Column>
       </StyledLogin>
     </AppLayout>
@@ -40,7 +52,7 @@ const StyledLogin = styled.div`
   width: 100%;
   height: 100vh;
   padding: 180px 12px 97px;
-  background-image: url('loginBackground.svg');
+  background-image: url('/loginBackground.svg');
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;

--- a/apps/mobile/src/constants/common/constant.ts
+++ b/apps/mobile/src/constants/common/constant.ts
@@ -15,3 +15,8 @@ export const SIDE: Record<Side, string> = {
   GROOM: '신랑',
   BRIDE: '신부',
 };
+
+export const TOKEN = {
+  ACCESS: 'access-token',
+  REFRESH: 'refresh-token',
+};

--- a/apps/mobile/src/services/auth/api.ts
+++ b/apps/mobile/src/services/auth/api.ts
@@ -1,0 +1,8 @@
+import { married } from '@/apis/instance/instance';
+import { PostLoginReq } from '@/types/auth/remote';
+
+export const postLogin = async ({ code, provider }: PostLoginReq) => {
+  const { data } = await married.post('/auth/login', { code, provider });
+
+  return data;
+};

--- a/apps/mobile/src/services/auth/mutations.ts
+++ b/apps/mobile/src/services/auth/mutations.ts
@@ -3,7 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import { postLogin } from './api';
 import { useRouter } from 'next/navigation';
 import { ROUTES, TOKEN } from '@/constants/common/constant';
-import { Cookie } from '@/apis/storage/cookie';
+import { Storage } from '@/apis/storage/storage';
 
 export const useLoginMutation = () => {
   const router = useRouter();
@@ -12,13 +12,13 @@ export const useLoginMutation = () => {
     mutationFn: ({ code, provider }: PostLoginReq) => postLogin({ code, provider }),
     onSuccess: (res) => {
       const { accessToken, refreshToken, provider } = res;
-      Cookie.setItem(TOKEN.ACCESS, accessToken);
-      Cookie.setItem(TOKEN.REFRESH, refreshToken);
-      Cookie.setItem('type', provider);
+      Storage.setItem(TOKEN.ACCESS, accessToken);
+      Storage.setItem(TOKEN.REFRESH, refreshToken);
+      Storage.setItem('type', provider);
       router.replace(ROUTES.HOME);
     },
     onError: () => {
-      Cookie.removeAll();
+      localStorage.clear();
       alert('로그인에 실패했습니다. 잠시후 시도해주세요.');
       router.push(ROUTES.LOGIN);
     },

--- a/apps/mobile/src/services/auth/mutations.ts
+++ b/apps/mobile/src/services/auth/mutations.ts
@@ -1,0 +1,28 @@
+import { PostLoginReq } from '@/types/auth/remote';
+import { useMutation } from '@tanstack/react-query';
+import { postLogin } from './api';
+import { useRouter } from 'next/navigation';
+import { ROUTES, TOKEN } from '@/constants/common/constant';
+import { Cookie } from '@/apis/storage/cookie';
+
+export const useLoginMutation = () => {
+  const router = useRouter();
+
+  const { mutate: loginMutate, ...restMutation } = useMutation({
+    mutationFn: ({ code, provider }: PostLoginReq) => postLogin({ code, provider }),
+    onSuccess: (res) => {
+      const { accessToken, refreshToken, provider } = res;
+      Cookie.setItem(TOKEN.ACCESS, accessToken);
+      Cookie.setItem(TOKEN.REFRESH, refreshToken);
+      Cookie.setItem('type', provider);
+      router.replace(ROUTES.HOME);
+    },
+    onError: () => {
+      Cookie.removeAll();
+      alert('로그인에 실패했습니다. 잠시후 시도해주세요.');
+      router.push(ROUTES.LOGIN);
+    },
+  });
+
+  return { loginMutate, ...restMutation };
+};


### PR DESCRIPTION
## 📄 Summary

> 로그인 API 연동 작업을 진행했습니다.

<br>

## 🔨 Tasks

- 로그인 API 연동
- 로그인 관련 React-Query 작성
- 페이지내 적용

<br>

## 🙋🏻 More


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 카카오 및 네이버 소셜 로그인 연동을 위한 콜백 컴포넌트가 추가되었습니다.
  * 카카오/네이버 로그인 버튼 클릭 시 환경 변수에 설정된 URL로 이동하도록 개선되었습니다.
  * 로그인 성공 시 토큰을 로컬 스토리지에 저장하고, 실패 시 로컬 스토리지를 초기화하는 기능이 추가되었습니다.
  * 모든 쿠키를 한 번에 삭제하는 기능이 추가되었습니다.

* **기타**
  * 토큰 관련 문자열 상수가 추가되었습니다.
  * 로그인 API 서비스 함수 및 커스텀 로그인 훅이 추가되었습니다.
  * 로그인 페이지의 배경 이미지 경로가 절대 경로로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->