### PR TITLE
feat(#112): 청첩장 리스트 API 연동

### DIFF
--- a/apps/mobile/src/apis/token/token.ts
+++ b/apps/mobile/src/apis/token/token.ts
@@ -1,0 +1,12 @@
+import { TOKEN } from '@/constants/common/constant';
+import { Storage } from '../storage/storage';
+
+const authorization = () => {
+  return {
+    headers: {
+      Authorization: `Bearer ${Storage.getItem(TOKEN.ACCESS)}`,
+    },
+  };
+};
+
+export default authorization;

--- a/apps/mobile/src/components/home/InvitationItem/InvitationItem.tsx
+++ b/apps/mobile/src/components/home/InvitationItem/InvitationItem.tsx
@@ -9,23 +9,24 @@ import dayjs from 'dayjs';
 import { useRouter } from 'next/navigation';
 import styled from 'styled-components';
 import PasswordModal from '../PasswordModal/PasswordModal';
+import { getDate } from '@/utils/getDate';
+import { getHour } from '@/utils/getHour';
 
 interface InvitationItemProps {
   id: number;
   title: string;
-  date: string;
-  hour: string;
+  updateAt: string;
 }
 
-const InvitationItem = ({ id, title, date, hour }: InvitationItemProps) => {
+const InvitationItem = ({ id, title, updateAt }: InvitationItemProps) => {
   const router = useRouter();
   const overlay = useOverlay();
 
-  const weddingDate = dayjs().isSame(dayjs(date), 'day');
+  const weddingDate = dayjs().isSame(dayjs(updateAt), 'day');
 
   const handleMoveGuestBook = () => {
     overlay.open(({ isOpen, close }) => (
-      <PasswordModal isOpen={isOpen} onClose={close} password="1234" id={id}/>
+      <PasswordModal isOpen={isOpen} onClose={close} password="1234" id={id} />
     ));
   };
 
@@ -44,10 +45,10 @@ const InvitationItem = ({ id, title, date, hour }: InvitationItemProps) => {
           </Text>
           <Row gap={4}>
             <Text fontType="P3" color={color.G80}>
-              {date}
+              {getDate(updateAt)}
             </Text>
             <Text fontType="P3" color={color.G80}>
-              {hour}
+              {getHour(updateAt)}
             </Text>
           </Row>
         </Column>

--- a/apps/mobile/src/components/home/InvitationList/InvitationList.tsx
+++ b/apps/mobile/src/components/home/InvitationList/InvitationList.tsx
@@ -3,25 +3,12 @@ import InvitationItem from '../InvitationItem/InvitationItem';
 import { styled } from 'styled-components';
 import { color } from '@merried/design-system';
 import { flex } from '@merried/utils';
-
-interface InvitationItemProps {
-  id: number;
-  title: string;
-  date: string;
-  hour: string;
-}
-
-const exampleData: InvitationItemProps[] = [
-  { id: 1, title: '김예진 결혼식에 초대합니다', date: '2025.05.10', hour: '15:00' },
-  { id: 2, title: '송윤서 웨딩 초대장', date: '2025.05.10', hour: '11:30' },
-  { id: 3, title: '강민지 & 이준호', date: '2025.06.15', hour: '14:00' },
-  { id: 4, title: '유진 & 태형 결혼식', date: '2025.07.02', hour: '16:30' },
-  { id: 5, title: '지원 & 수혁 결혼식', date: '2025.07.20', hour: '13:00' },
-  { id: 6, title: '소연 & 민재 초대장', date: '2025.06.19', hour: '12:00' },
-];
+import { useCardListQuery } from '@/services/card/queries';
 
 const InvitationList = () => {
-  if (exampleData.length === 0) {
+  const { data } = useCardListQuery();
+
+  if (data?.length === 0) {
     return (
       <EmptyContainer>
         <Column gap={10} alignItems="center">
@@ -38,13 +25,12 @@ const InvitationList = () => {
 
   return (
     <ListContainer>
-      {exampleData.map((item, idx) => (
+      {data?.map((item, idx) => (
         <InvitationItem
           key={idx}
-          id={item.id}
+          id={Number(item.id)}
           title={item.title}
-          date={item.date}
-          hour={item.hour}
+          updateAt={item.updateAt}
         />
       ))}
     </ListContainer>

--- a/apps/mobile/src/constants/common/constant.ts
+++ b/apps/mobile/src/constants/common/constant.ts
@@ -20,3 +20,7 @@ export const TOKEN = {
   ACCESS: 'access-token',
   REFRESH: 'refresh-token',
 };
+
+export const KEY = {
+  CARD_LIST: 'card-list',
+};

--- a/apps/mobile/src/services/auth/mutations.ts
+++ b/apps/mobile/src/services/auth/mutations.ts
@@ -11,10 +11,9 @@ export const useLoginMutation = () => {
   const { mutate: loginMutate, ...restMutation } = useMutation({
     mutationFn: ({ code, provider }: PostLoginReq) => postLogin({ code, provider }),
     onSuccess: (res) => {
-      const { accessToken, refreshToken, provider } = res;
+      const { accessToken, refreshToken } = res;
       Storage.setItem(TOKEN.ACCESS, accessToken);
       Storage.setItem(TOKEN.REFRESH, refreshToken);
-      Storage.setItem('type', provider);
       router.replace(ROUTES.HOME);
     },
     onError: () => {

--- a/apps/mobile/src/services/card/api.ts
+++ b/apps/mobile/src/services/card/api.ts
@@ -1,0 +1,9 @@
+import { married } from '@/apis/instance/instance';
+import authorization from '@/apis/token/token';
+import { CardListRes } from '@/types/card/remote';
+
+export const getCardList = async () => {
+  const { data } = await married.get<CardListRes>('/cards/list', authorization());
+
+  return data;
+};

--- a/apps/mobile/src/services/card/queries.ts
+++ b/apps/mobile/src/services/card/queries.ts
@@ -1,0 +1,13 @@
+import { KEY } from '@/constants/common/constant';
+import { useQuery } from '@tanstack/react-query';
+import { getCardList } from './api';
+
+export const useCardListQuery = () => {
+  const { data, ...restQuery } = useQuery({
+    queryKey: [KEY.CARD_LIST],
+    queryFn: getCardList,
+    retry: false,
+  });
+
+  return { data, ...restQuery };
+};

--- a/apps/mobile/src/types/card/client.ts
+++ b/apps/mobile/src/types/card/client.ts
@@ -1,0 +1,5 @@
+export interface CardList {
+  id: string;
+  title: string;
+  updateAt: string;
+}

--- a/apps/mobile/src/types/card/remote.ts
+++ b/apps/mobile/src/types/card/remote.ts
@@ -1,0 +1,3 @@
+import { CardList } from './client';
+
+export type CardListRes = CardList[];

--- a/apps/mobile/src/utils/getDate.ts
+++ b/apps/mobile/src/utils/getDate.ts
@@ -1,0 +1,5 @@
+import dayjs from 'dayjs';
+
+export const getDate = (isoString: string) => {
+  return dayjs(isoString).format('YYYY.MM.DD');
+};

--- a/apps/mobile/src/utils/getHour.ts
+++ b/apps/mobile/src/utils/getHour.ts
@@ -1,0 +1,5 @@
+import dayjs from 'dayjs';
+
+export const getHour = (isoString: string) => {
+  return dayjs(isoString).format('HH:mm');
+};


### PR DESCRIPTION
## 📄 Summary

> 청첩장 리스트 API를 연동을 진행했습니다.

<br>

## 🔨 Tasks

- API 연동
- React Query 작성
- 페이지 적용

<br>

## 🙋🏻 More


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 카드 목록을 불러오는 API 및 React Query 훅이 추가되었습니다.
  * 카드 목록 데이터 타입 및 응답 타입이 새롭게 정의되었습니다.
  * 날짜 및 시간 포맷팅을 위한 유틸리티 함수가 추가되었습니다.
  * 인증 토큰을 헤더에 포함하는 함수가 추가되었습니다.
  * 카드 리스트 조회를 위한 상수가 추가되었습니다.

* **기능 개선**
  * 초대 아이템 컴포넌트가 날짜와 시간을 하나의 타임스탬프 속성으로 통합하여 처리하도록 변경되었습니다.
  * 초대 목록이 예시 데이터 대신 실제 API에서 불러온 데이터로 렌더링되도록 개선되었습니다.

* **버그 수정**
  * 로그인 시 provider 정보 저장 로직이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->