### PR TITLE
fix(#118): 프리렌더 문제 해결

### DIFF
--- a/apps/mobile/src/app/callback/kakao/page.tsx
+++ b/apps/mobile/src/app/callback/kakao/page.tsx
@@ -1,23 +1,15 @@
 'use client';
+export const dynamic = 'force-dynamic';
 
-import { useLoginMutation } from '@/services/auth/mutations';
-import { useSearchParams } from 'next/navigation';
-import { useEffect, useRef } from 'react';
+import { CallbackKakaoContent } from '@/components/login';
+import { Suspense } from 'react';
 
 const CallbackKakao = () => {
-  const searchParams = useSearchParams();
-  const { loginMutate } = useLoginMutation();
-  const alreadyRun = useRef(false);
-
-  useEffect(() => {
-    const code = searchParams.get('code');
-    if (code && !alreadyRun.current) {
-      alreadyRun.current = true;
-      loginMutate({ code, provider: 'KAKAO' });
-    }
-  }, [searchParams, loginMutate]);
-
-  return <></>;
+  return (
+    <Suspense>
+      <CallbackKakaoContent />
+    </Suspense>
+  );
 };
 
 export default CallbackKakao;

--- a/apps/mobile/src/app/callback/naver/page.tsx
+++ b/apps/mobile/src/app/callback/naver/page.tsx
@@ -1,23 +1,14 @@
 'use client';
 
-import { useLoginMutation } from '@/services/auth/mutations';
-import { useSearchParams } from 'next/navigation';
-import { useEffect, useRef } from 'react';
+import { CallbackNaverContent } from '@/components/login';
+import { Suspense } from 'react';
 
 const CallbackNaver = () => {
-  const searchParams = useSearchParams();
-  const { loginMutate } = useLoginMutation();
-  const alreadyRun = useRef(false);
-
-  useEffect(() => {
-    const code = searchParams.get('code');
-    if (code && !alreadyRun.current) {
-      alreadyRun.current = true;
-      loginMutate({ code, provider: 'NAVER' });
-    }
-  }, [searchParams, loginMutate]);
-
-  return <></>;
+  return (
+    <Suspense>
+      <CallbackNaverContent />
+    </Suspense>
+  );
 };
 
 export default CallbackNaver;

--- a/apps/mobile/src/components/login/CallbackKakaoContent/CallbackKakaoContent.tsx
+++ b/apps/mobile/src/components/login/CallbackKakaoContent/CallbackKakaoContent.tsx
@@ -1,0 +1,21 @@
+import { useLoginMutation } from '@/services/auth/mutations';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+
+const CallbackKakaoContent = () => {
+  const searchParams = useSearchParams();
+  const { loginMutate } = useLoginMutation();
+  const alreadyRun = useRef(false);
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+    if (code && !alreadyRun.current) {
+      alreadyRun.current = true;
+      loginMutate({ code, provider: 'KAKAO' });
+    }
+  }, [searchParams, loginMutate]);
+
+  return <></>;
+};
+
+export default CallbackKakaoContent;

--- a/apps/mobile/src/components/login/CallbackNaverContent/CallbackNaverContent.tsx
+++ b/apps/mobile/src/components/login/CallbackNaverContent/CallbackNaverContent.tsx
@@ -1,0 +1,21 @@
+import { useLoginMutation } from '@/services/auth/mutations';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+
+const CallbackNaverContent = () => {
+  const searchParams = useSearchParams();
+  const { loginMutate } = useLoginMutation();
+  const alreadyRun = useRef(false);
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+    if (code && !alreadyRun.current) {
+      alreadyRun.current = true;
+      loginMutate({ code, provider: 'NAVER' });
+    }
+  }, [searchParams, loginMutate]);
+
+  return <></>;
+};
+
+export default CallbackNaverContent;

--- a/apps/mobile/src/components/login/index.ts
+++ b/apps/mobile/src/components/login/index.ts
@@ -1,0 +1,2 @@
+export { default as CallbackKakaoContent } from './CallbackKakaoContent/CallbackKakaoContent';
+export { default as CallbackNaverContent } from './CallbackNaverContent/CallbackNaverContent';


### PR DESCRIPTION
## 📄 Summary

> 네이버, 카카오 oauth를 진행하면서 반환받는 callback페이지에서 생기는 prerendering 문제를 해결했습니다.

<br>

## 🔨 Tasks

- content로 페이지 분리
- suspense로 에러 해결

<br>

## 🙋🏻 More
