### PR TITLE
feat(#142): 참석자 추가 API 연동

### DIFF
--- a/apps/mobile/src/app/attendee/invite/[id]/page.tsx
+++ b/apps/mobile/src/app/attendee/invite/[id]/page.tsx
@@ -7,12 +7,14 @@ import { color } from '@merried/design-system';
 import { useRouter } from 'next/navigation';
 import styled from 'styled-components';
 
-const Invite = () => {
+const Invite = ({ params }: { params: { id: string } }) => {
   const router = useRouter();
 
   const handleMoveManage = () => {
     router.push(ROUTES.MANAGE);
   };
+
+  console.log(params.id);
 
   return (
     <AppLayout
@@ -23,7 +25,7 @@ const Invite = () => {
       backgroundColor={color.G0}
     >
       <StyledInvite>
-        <InviteContent />
+        <InviteContent id={params.id} />
       </StyledInvite>
     </AppLayout>
   );

--- a/apps/mobile/src/app/attendee/page.tsx
+++ b/apps/mobile/src/app/attendee/page.tsx
@@ -1,32 +1,19 @@
 'use client';
 
 import AttendeeList from '@/components/attendee/AttendeeList/AttendeeList';
-import { ROUTES } from '@/constants/common/constant';
 import AppLayout from '@/layouts/AppLayout';
 import { color } from '@merried/design-system';
-import { ActionButton, Column, Text } from '@merried/ui';
+import { Text } from '@merried/ui';
 import { flex } from '@merried/utils';
-import { useRouter } from 'next/navigation';
 import styled from 'styled-components';
 
 const Attendee = () => {
-  const router = useRouter();
-
-  const handleMoveInvite = () => {
-    router.push(ROUTES.INVITE);
-  };
-
   return (
     <AppLayout footer backgroundColor={color.G0}>
       <StyledAttendee>
-        <Column gap={20}>
-          <Text fontType="H2" color={color.G900}>
-            참석자 관리
-          </Text>
-          <ActionButton icon="ADD_ICON" onClick={handleMoveInvite}>
-            참석자 추가
-          </ActionButton>
-        </Column>
+        <Text fontType="H2" color={color.G900}>
+          참석자 관리
+        </Text>
         <AttendeeList />
       </StyledAttendee>
     </AppLayout>

--- a/apps/mobile/src/components/attendee/InviteContent/InviteContent.tsx
+++ b/apps/mobile/src/components/attendee/InviteContent/InviteContent.tsx
@@ -2,39 +2,65 @@ import ButtonGroup from '@/components/common/ButtonGroup/ButtonGroup';
 import DesktopButtonGroup from '@/components/common/ButtonGroup/DesktopButtonGroup';
 import { Button, Column, Input } from '@merried/ui';
 import { flex } from '@merried/utils';
-import { useState } from 'react';
 import styled from 'styled-components';
 import { useInput } from './InviteContent.hooks';
+import { useState } from 'react';
+import { PostAttendeeReq } from '@/types/invitation/remote';
+import { useAttendeeMutation } from '@/services/attendee/mutations';
 
-const InviteContent = () => {
+interface InviteContentProps {
+  id: string;
+}
+
+const InviteContent = ({ id }: InviteContentProps) => {
   const { handleCountChange, handleCountBlur, count } = useInput();
+  const { attendeeMutate } = useAttendeeMutation();
+  const [attendee, setAttendee] = useState<PostAttendeeReq>({
+    cardId: id,
+    side: 'GROOM',
+    name: '',
+    phoneNumber: '',
+    numberOfAttendees: 1,
+    isAttending: true,
+    hasSentGift: true,
+    mealPreference: 'PLANNED',
+  });
 
-  const [name, setName] = useState('');
-  const [phoneNumber, setPhoneNumber] = useState('');
+  const handleSubmitAttendee = () => {
+    attendeeMutate(attendee);
+  };
 
   return (
     <StyledInviteContent>
       <Column gap={28}>
         <ButtonGroup
           buttons={[
-            { label: '신랑측', onClick: () => {} },
-            { label: '신부측', onClick: () => {} },
+            {
+              label: '신랑측',
+              onClick: () => setAttendee((prev) => ({ ...prev, side: 'GROOM' })),
+            },
+            {
+              label: '신부측',
+              onClick: () => setAttendee((prev) => ({ ...prev, side: 'BRIDE' })),
+            },
           ]}
         />
         <Input
           label="이름"
           placeholder="이름을 입력해주세요"
           type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={attendee.name}
+          onChange={(e) => setAttendee((prev) => ({ ...prev, name: e.target.value }))}
           name="name"
         />
         <Input
           label="전화번호"
           placeholder="전화번호를 입력해주세요"
           type="text"
-          value={phoneNumber}
-          onChange={(e) => setPhoneNumber(e.target.value)}
+          value={attendee.phoneNumber}
+          onChange={(e) =>
+            setAttendee((prev) => ({ ...prev, phoneNumber: e.target.value }))
+          }
           name="phoneNumber"
         />
         <Input
@@ -46,35 +72,70 @@ const InviteContent = () => {
           min={1}
           step={1}
           value={count}
-          onChange={handleCountChange}
+          onChange={(e) => {
+            handleCountChange(e);
+            const val = e.target.value === '1' ? 1 : Number(e.target.value);
+            setAttendee((prev) => ({
+              ...prev,
+              numberOfAttendees: val < 1 ? 1 : val,
+            }));
+          }}
           onBlur={handleCountBlur}
         />
         <Column gap={24}>
           <ButtonGroup
             title="참석 여부"
             buttons={[
-              { label: '참석', onClick: () => {} },
-              { label: '불참석', onClick: () => {} },
+              {
+                label: '참석',
+                onClick: () => setAttendee((prev) => ({ ...prev, isAttending: true })),
+              },
+              {
+                label: '불참석',
+                onClick: () => setAttendee((prev) => ({ ...prev, isAttending: false })),
+              },
             ]}
           />
           <ButtonGroup
             title="축의금 여부"
             buttons={[
-              { label: 'O', onClick: () => {} },
-              { label: 'X', onClick: () => {} },
+              {
+                label: 'O',
+                onClick: () => setAttendee((prev) => ({ ...prev, hasSentGift: true })),
+              },
+              {
+                label: 'X',
+                onClick: () => setAttendee((prev) => ({ ...prev, hasSentGift: false })),
+              },
             ]}
           />
           <DesktopButtonGroup
             title="식사 여부"
             buttons={[
-              { label: '예정', onClick: () => {} },
-              { label: '안함', onClick: () => {} },
-              { label: '미정', onClick: () => {} },
+              {
+                label: '예정',
+                onClick: () =>
+                  setAttendee((prev) => ({ ...prev, mealPreference: 'PLANNED' })),
+              },
+              {
+                label: '안함',
+                onClick: () =>
+                  setAttendee((prev) => ({ ...prev, mealPreference: 'SKIP' })),
+              },
+              {
+                label: '미정',
+                onClick: () =>
+                  setAttendee((prev) => ({ ...prev, mealPreference: 'UNDECIDED' })),
+              },
             ]}
             height="52px"
           />
         </Column>
-        <Button width="100%" onClick={() => {}} styleType={name ? 'DEFAULT' : 'DISABLED'}>
+        <Button
+          width="100%"
+          onClick={handleSubmitAttendee}
+          styleType={attendee.name && attendee.phoneNumber ? 'DEFAULT' : 'DISABLED'}
+        >
           참석자 추가하기
         </Button>
       </Column>

--- a/apps/mobile/src/components/home/InvitationItem/InvitationItem.tsx
+++ b/apps/mobile/src/components/home/InvitationItem/InvitationItem.tsx
@@ -2,7 +2,7 @@ import Badge from '@/components/common/Badge/Badge';
 import { ROUTES } from '@/constants/common/constant';
 import { color } from '@merried/design-system';
 import { IconBoldLetter, IconBoldList, IconBoldShare, IconFolder } from '@merried/icon';
-import { Column, Row, Text } from '@merried/ui';
+import { ActionButton, Column, Row, Text } from '@merried/ui';
 import { flex } from '@merried/utils';
 import { useOverlay } from '@toss/use-overlay';
 import dayjs from 'dayjs';
@@ -42,24 +42,39 @@ const InvitationItem = ({ id, title, updateAt }: InvitationItemProps) => {
     });
   };
 
+  const handleMoveAttendee = () => {
+    router.push(`${ROUTES.INVITE}/${id}`);
+  };
+
   return (
     <StyledInvitationItem>
       <Background src="images/type01.svg" alt="초대장 배경" />
       <IconFolder width="100%" height={194.38} stroke={color.G30} />
       <ItemContent>
-        <Column gap={4}>
-          <Text fontType="H4" color={color.G900}>
-            {title}
-          </Text>
-          <Row gap={4}>
-            <Text fontType="P3" color={color.G80}>
-              {getDate(updateAt)}
+        <Row width="100%" justifyContent="space-between">
+          <Column gap={4}>
+            <Text fontType="H4" color={color.G900}>
+              {title}
             </Text>
-            <Text fontType="P3" color={color.G80}>
-              {getHour(updateAt)}
+            <Row gap={4}>
+              <Text fontType="P3" color={color.G80}>
+                {getDate(updateAt)}
+              </Text>
+              <Text fontType="P3" color={color.G80}>
+                {getHour(updateAt)}
+              </Text>
+            </Row>
+          </Column>
+          <ActionButton
+            onClick={handleMoveAttendee}
+            width={100}
+            background={color.primary2}
+          >
+            <Text fontType="Button3" color={color.primary}>
+              참석자 추가
             </Text>
-          </Row>
-        </Column>
+          </ActionButton>
+        </Row>
         <Row alignItems="center" gap={8}>
           <Badge
             icon={IconBoldLetter}

--- a/apps/mobile/src/services/attendee/api.ts
+++ b/apps/mobile/src/services/attendee/api.ts
@@ -4,6 +4,7 @@ import {
   GetAttendee,
   GetAttendeeParms,
   PostAccountReq,
+  PostAttendeeReq,
   PostIntentionReq,
 } from '@/types/invitation/remote';
 
@@ -45,6 +46,37 @@ export const getAttendee = async (
     ...authorization(),
     params: { isAttendee, isEating, hasSentGift },
   });
+
+  return data;
+};
+
+export const postAttendee = async ({
+  cardId,
+  side,
+  name,
+  phoneNumber,
+  numberOfAttendees,
+  mealPreference,
+  hasSentGift,
+  isAttending,
+}: PostAttendeeReq) => {
+  const { data } = await married.post(
+    '/attendees',
+    {},
+    {
+      ...authorization(),
+      params: {
+        cardId,
+        side,
+        name,
+        phoneNumber,
+        numberOfAttendees,
+        mealPreference,
+        hasSentGift,
+        isAttending,
+      },
+    }
+  );
 
   return data;
 };

--- a/apps/mobile/src/services/attendee/mutations.ts
+++ b/apps/mobile/src/services/attendee/mutations.ts
@@ -1,7 +1,13 @@
 import { useMutation } from '@tanstack/react-query';
-import { postAccount, postIntention } from './api';
-import { PostAccountReq, PostIntentionReq } from '@/types/invitation/remote';
+import { postAccount, postAttendee, postIntention } from './api';
+import {
+  PostAccountReq,
+  PostAttendeeReq,
+  PostIntentionReq,
+} from '@/types/invitation/remote';
 import { useSetAccountStepStore } from '@/stores/invitation/accountStep';
+import { useRouter } from 'next/navigation';
+import { ROUTES } from '@/constants/common/constant';
 
 export const useAccount = () => {
   const setAccountStep = useSetAccountStepStore();
@@ -41,4 +47,39 @@ export const useIntention = () => {
   });
 
   return { intentionMutate, ...restMutate };
+};
+
+export const useAttendeeMutation = () => {
+  const router = useRouter();
+
+  const { mutate: attendeeMutate, ...restMutate } = useMutation({
+    mutationFn: ({
+      cardId,
+      side,
+      name,
+      phoneNumber,
+      numberOfAttendees,
+      mealPreference,
+      isAttending,
+      hasSentGift,
+    }: PostAttendeeReq) =>
+      postAttendee({
+        cardId,
+        side,
+        name,
+        phoneNumber,
+        numberOfAttendees,
+        mealPreference,
+        isAttending,
+        hasSentGift,
+      }),
+    onSuccess: () => {
+      router.push(ROUTES.MANAGE);
+    },
+    onError: () => {
+      alert('잠시후 다시 시도해주세요.');
+    },
+  });
+
+  return { attendeeMutate, restMutate };
 };

--- a/apps/mobile/src/types/invitation/remote.ts
+++ b/apps/mobile/src/types/invitation/remote.ts
@@ -15,6 +15,17 @@ export interface PostIntentionReq {
   mealPreference: 'PLANNED' | 'SKIP' | 'UNDECIDED';
 }
 
+export interface PostAttendeeReq {
+  cardId: string;
+  side: 'GROOM' | 'BRIDE';
+  name: string;
+  phoneNumber: string;
+  numberOfAttendees: number;
+  isAttending: boolean;
+  hasSentGift: boolean;
+  mealPreference: 'PLANNED' | 'SKIP' | 'UNDECIDED';
+}
+
 export type GetAttendee = Attendee[];
 
 export interface GetAttendeeParms {


### PR DESCRIPTION
## 📄 Summary

> 참석자 추가 API 연동 작업을 진행했습니다.

<br>

## 🔨 Tasks

- API 연동
- React Query 작성
- 페이지 적용

<br>

## 🙋🏻 More


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 초대장 상세 화면에서 "참석자 추가" 버튼이 추가되어, 참석자를 직접 추가할 수 있습니다.
  * 참석자 정보를 입력하고 제출할 수 있는 폼이 제공됩니다. 이름, 연락처, 참석 인원, 참석 여부, 식사 여부, 축의금 발송 여부 등을 입력할 수 있습니다.

* **개선 사항**
  * 참석자 추가 폼이 하나의 입력 상태로 통합되어 입력 및 제출이 간편해졌습니다.

* **버그 수정**
  * 참석자 추가 버튼 및 관련 UI가 중복으로 노출되지 않도록 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->