### PR TITLE
feat(web): 청접장 더미 미리보기

### DIFF
--- a/apps/web/public/IconNaver.svg
+++ b/apps/web/public/IconNaver.svg
@@ -1,0 +1,3 @@
+<svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.3217 8.50161L5.40478 0H0.5V15.8846H5.63835V7.38297L11.5552 15.8846H16.46V0H11.3217V8.50161Z" fill="#03CF5D"/>
+</svg>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,6 +6,9 @@ import StyledComponentsRegistry from './providers/StyledComponentsProvider';
 export const metadata = {
   title: '우리 결혼할래요?',
   description: '우리 결혼할래요? 의 웹사이트 입니다.',
+  icons: {
+    icon: '/LogoFull.svg',
+  },
 };
 
 interface Props {

--- a/apps/web/src/app/library/page.tsx
+++ b/apps/web/src/app/library/page.tsx
@@ -44,6 +44,5 @@ const StyledLibrary = styled.div`
 const InvitationListWrapper = styled.div`
   flex: 1;
   overflow: hidden;
-  display: flex;
-  flex-direction: column;
+  ${flex({ flexDirection: 'column' })}
 `;

--- a/apps/web/src/app/providers/Provider.tsx
+++ b/apps/web/src/app/providers/Provider.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from 'react';
 import { GlobalStyle } from '@merried/design-system';
 import { RecoilRoot } from 'recoil';
 import { OverlayProvider } from '@toss/use-overlay';
+import { ToastProvider } from './ToastProvider';
 
 interface ProviderProps {
   children: ReactNode;
@@ -12,10 +13,12 @@ interface ProviderProps {
 const Provider = ({ children }: ProviderProps) => {
   return (
     <RecoilRoot>
-      <OverlayProvider>
-        <GlobalStyle />
-        {children}
-      </OverlayProvider>
+      <ToastProvider>
+        <OverlayProvider>
+          <GlobalStyle />
+          {children}
+        </OverlayProvider>
+      </ToastProvider>
     </RecoilRoot>
   );
 };

--- a/apps/web/src/app/providers/ToastProvider.tsx
+++ b/apps/web/src/app/providers/ToastProvider.tsx
@@ -1,0 +1,19 @@
+import { Toast } from '@/components/common';
+import { useToastController } from '@/utils';
+import { ReactNode } from 'react';
+import ReactDOM from 'react-dom';
+
+export const ToastProvider = ({ children }: { children: ReactNode }) => {
+  const toast = useToastController();
+
+  return (
+    <>
+      {children}
+      {toast &&
+        ReactDOM.createPortal(
+          <Toast label={toast.label} type={toast.type} />,
+          document.body
+        )}
+    </>
+  );
+};

--- a/apps/web/src/components/common/Header/header.hook.ts
+++ b/apps/web/src/components/common/Header/header.hook.ts
@@ -33,6 +33,8 @@ export const usePostCardParams = () => {
   const urlShareStyle = useUrlShareStyleValueStore();
   const componentOrder = useComponentOrderValueStore();
 
+  const nullIfEmpty = (value: string | undefined | null) => (value === '' ? null : value);
+
   const getDownloadUrl = (presignedUrl: string) => {
     const withoutQuery = presignedUrl.split('?')[0];
     const fileKey = withoutQuery.replace(/^https:\/\/[^/]+\//, '');
@@ -61,14 +63,14 @@ export const usePostCardParams = () => {
       : [];
 
     const baseParams = {
-      title: main.title,
+      title: nullIfEmpty(main.title),
       templateId: main.templateId,
       invitationSetting: {
         pointColor: invitationSetup.pointColor,
         font: invitationSetup.invitationFont,
       },
       mainPageSetting: {
-        picture: uploadedPicture,
+        picture: nullIfEmpty(uploadedPicture),
         font: mainScreen.letteringFont,
         lettering: [mainScreen.letteringText],
         letteringColor: mainScreen.letteringColor,

--- a/apps/web/src/components/common/Toast/index.tsx
+++ b/apps/web/src/components/common/Toast/index.tsx
@@ -1,0 +1,64 @@
+import { color } from '@merried/design-system';
+import { IconError, IconSuccess } from '@merried/icon';
+import { Text } from '@merried/ui';
+import { flex } from '@merried/utils';
+import styled, { CSSProperties } from 'styled-components';
+
+interface Props {
+  label: string;
+  width?: CSSProperties['width'];
+  type: 'ERROR' | 'SUCCESS';
+}
+
+const Toast = ({ label, width, type }: Props) => {
+  return (
+    <StyledToast $type={type} style={{ width }}>
+      {type === 'ERROR' ? (
+        <IconError width={14} height={14} />
+      ) : (
+        <IconSuccess width={14} height={14} />
+      )}
+      <Text fontType="Button3" color={color.G0}>
+        {label}
+      </Text>
+    </StyledToast>
+  );
+};
+
+export default Toast;
+
+const StyledToast = styled.div<{ $type: 'ERROR' | 'SUCCESS' }>`
+  ${flex({ alignItems: 'center' })}
+  position: fixed;
+  gap: 10px;
+  bottom: 88px;
+  background-color: ${(p) => (p.$type === 'ERROR' ? color.red : '#6DDC5C')};
+  width: auto;
+  height: 50px;
+  padding: 16px 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-radius: 8px;
+  z-index: 1000;
+  opacity: 0;
+  animation: fadeInOut 3s ease forwards;
+
+  @keyframes fadeInOut {
+    0% {
+      opacity: 0;
+      transform: translate(-50%, 20px);
+    }
+    10% {
+      opacity: 1;
+      transform: translate(-50%, 0);
+    }
+    90% {
+      opacity: 1;
+      transform: translate(-50%, 0);
+    }
+    100% {
+      opacity: 0;
+      transform: translate(-50%, 20px);
+    }
+  }
+`;

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -1,3 +1,4 @@
 export { default as Header } from './Header/Header';
 export { default as CustomText } from './CustomText/CustomText';
 export { default as FindAddressModal } from './FindAddressModal';
+export { default as Toast } from './Toast';

--- a/apps/web/src/components/form/Preview/Direction/BrandButton/index.tsx
+++ b/apps/web/src/components/form/Preview/Direction/BrandButton/index.tsx
@@ -2,17 +2,39 @@ import { color } from '@merried/design-system';
 import { Text } from '@merried/ui';
 import { flex } from '@merried/utils';
 import Image from 'next/image';
+import { useCallback } from 'react';
 import styled from 'styled-components';
 
 interface BrandButtonProps {
-  onClick: () => void;
   src: string;
-  name: string;
+  name: '네이버지도' | '카카오맵';
+  address: string;
 }
 
-const BrandButton = ({ onClick, src, name }: BrandButtonProps) => {
+const BrandButton = ({ src, name, address }: BrandButtonProps) => {
+  const handleClick = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    const geocoder = new window.kakao.maps.services.Geocoder();
+
+    geocoder.addressSearch(address, (result, status) => {
+      if (status === window.kakao.maps.services.Status.OK && result.length > 0) {
+        const { y, x } = result[0];
+
+        if (name === '카카오맵') {
+          const url = `https://map.kakao.com/link/to/${encodeURIComponent(address)},${y},${x}`;
+          window.open(url, '_blank');
+        } else if (name === '네이버지도') {
+          const url = `https://map.naver.com/p/search/${encodeURIComponent(address)}`;
+          window.open(url, '_blank');
+        }
+      } else {
+        alert('주소를 찾을 수 없습니다.');
+      }
+    });
+  }, [address, name]);
+
   return (
-    <StyledBrandButton onClick={onClick}>
+    <StyledBrandButton onClick={handleClick}>
       <Image width={20} height={20} src={src} alt="icon" />
       <Text fontType="Button2" color={color.G900}>
         {name}

--- a/apps/web/src/components/form/Preview/Direction/BrandButton/index.tsx
+++ b/apps/web/src/components/form/Preview/Direction/BrandButton/index.tsx
@@ -1,3 +1,4 @@
+import { showToast } from '@/utils';
 import { color } from '@merried/design-system';
 import { Text } from '@merried/ui';
 import { flex } from '@merried/utils';
@@ -28,7 +29,7 @@ const BrandButton = ({ src, name, address }: BrandButtonProps) => {
           window.open(url, '_blank');
         }
       } else {
-        alert('주소를 찾을 수 없습니다.');
+        showToast('주소를 찾을 수 없습니다', 'ERROR');
       }
     });
   }, [address, name]);

--- a/apps/web/src/components/form/Preview/Direction/KakaoMap/index.tsx
+++ b/apps/web/src/components/form/Preview/Direction/KakaoMap/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from 'next/image';
 import React, { useEffect, useState } from 'react';
 import { CustomOverlayMap, Map } from 'react-kakao-maps-sdk';

--- a/apps/web/src/components/form/Preview/Direction/Transportation/index.tsx
+++ b/apps/web/src/components/form/Preview/Direction/Transportation/index.tsx
@@ -1,4 +1,3 @@
-import { TRANSPORT_MAP } from '@/constants/form/constants';
 import { color } from '@merried/design-system';
 import { Text } from '@merried/ui';
 import { flex } from '@merried/utils';
@@ -14,7 +13,7 @@ const Transportation = ({ type, method }: TransportationProps) => {
     <div>
       <StyledTransportation>
         <Text fontType="H4" color={color.G900}>
-          {TRANSPORT_MAP[type]}
+          {type}
         </Text>
         <Text fontType="P2" color={color.G80} whiteSpace="pre-wrap">
           {method}

--- a/apps/web/src/components/form/Preview/Direction/index.tsx
+++ b/apps/web/src/components/form/Preview/Direction/index.tsx
@@ -62,7 +62,12 @@ const Direction = () => {
       </Row>
       <Row width="100%" alignItems="center" gap={19}>
         {BRAND.map(({ src, name }) => (
-          <BrandButton key={name} src={src} name={name} onClick={() => {}} />
+          <BrandButton
+            key={name}
+            src={src}
+            name={name as '네이버지도' | '카카오맵'}
+            address={mainAddress}
+          />
         ))}
       </Row>
       <Line />

--- a/apps/web/src/components/form/Preview/Direction/index.tsx
+++ b/apps/web/src/components/form/Preview/Direction/index.tsx
@@ -46,11 +46,11 @@ const Direction = () => {
         <KakaoMap address={mainAddress} />
       </Column>
       <Row width="100%" alignItems="center" justifyContent="space-between">
-        <Column gap={4} alignItems="flex-start">
-          <Text fontType="P2" color={color.G80}>
+        <Column width="60%" gap={4} alignItems="flex-start">
+          <Text width="100%" whiteSpace="normal" fontType="P2" color={color.G80}>
             {mainAddress}
           </Text>
-          <Text fontType="H4" color={color.G900}>
+          <Text fontType="H4" whiteSpace="normal" color={color.G900}>
             {buildingName}
           </Text>
         </Column>

--- a/apps/web/src/components/form/Preview/MainScreen/TextOverlay/index.tsx
+++ b/apps/web/src/components/form/Preview/MainScreen/TextOverlay/index.tsx
@@ -26,5 +26,5 @@ const StyledText = styled.div<{ $id: string; $font: string; $color: string }>`
   position: absolute;
   width: 100%;
   text-align: center;
-  white-space: pre-line;
+  white-space: pre;
 `;

--- a/apps/web/src/components/form/Preview/MainScreen/index.tsx
+++ b/apps/web/src/components/form/Preview/MainScreen/index.tsx
@@ -44,7 +44,12 @@ const MainScreen = ({ id, onScrollClick }: Props) => {
   }, [image]);
 
   return (
-    <StyledMainScreen $id={id} $imageUrl={backgroundUrl}>
+    <StyledMainScreen>
+      <BackgroundImage
+        src={backgroundUrl || `/templateFull${id}.png`}
+        $isShrinked={id === '5'}
+        alt="main background"
+      />
       {id === '7' && <SvgOverlay src="/template7Backgroud.svg" alt="overlay" />}
       <TextOverlay
         id={id}
@@ -68,15 +73,25 @@ const MainScreen = ({ id, onScrollClick }: Props) => {
 
 export default MainScreen;
 
-const StyledMainScreen = styled.div<{ $id: string; $imageUrl: string }>`
+const StyledMainScreen = styled.div`
   position: relative;
   width: 100%;
   height: 812px;
-  background-image: ${({ $imageUrl }) => `url(${$imageUrl})`};
-  background-size: cover;
-  background-position: center;
+  overflow: hidden;
   ${flex({ flexDirection: 'column', justifyContent: 'flex-end', alignItems: 'center' })}
   flex-shrink: 0;
+  background: ${color.G0};
+`;
+
+const BackgroundImage = styled.img<{ $isShrinked: boolean }>`
+  position: absolute;
+  top: ${({ $isShrinked }) => ($isShrinked ? '10px' : '0')};
+  left: 50%;
+  transform: translateX(-50%);
+  width: ${({ $isShrinked }) => ($isShrinked ? '94%' : '100%')};
+  height: ${({ $isShrinked }) => ($isShrinked ? '60%' : '100%')};
+  object-fit: cover;
+  z-index: 0;
 `;
 
 const ScrollTriggerButton = styled.div`

--- a/apps/web/src/components/library/GuestSnapModal/index.tsx
+++ b/apps/web/src/components/library/GuestSnapModal/index.tsx
@@ -75,8 +75,21 @@ const GuestSnapModal = ({ id, isOpen, onClose }: Props) => {
     }
   };
 
-  const thumbnailGroup =
-    selectedIndex !== null ? images.slice(selectedIndex, selectedIndex + 8) : [];
+  const THUMBNAIL_LIMIT = 8;
+
+  const start =
+    selectedIndex !== null
+      ? Math.max(
+          0,
+          Math.min(
+            selectedIndex - Math.floor(THUMBNAIL_LIMIT / 2),
+            images.length - THUMBNAIL_LIMIT
+          )
+        )
+      : 0;
+
+  const end = Math.min(images.length, start + THUMBNAIL_LIMIT);
+  const thumbnailGroup = images.slice(start, end);
 
   return (
     <BlurBackground $isOpen={isOpen}>
@@ -180,8 +193,8 @@ const GuestSnapModal = ({ id, isOpen, onClose }: Props) => {
                   key={idx}
                   src={img}
                   alt={`썸네일 ${idx}`}
-                  onClick={() => setSelectedIndex(selectedIndex + idx)}
-                  $active={idx === 0}
+                  onClick={() => setSelectedIndex(start + idx)}
+                  $active={start + idx === selectedIndex}
                 />
               ))}
             </Row>

--- a/apps/web/src/components/library/GuestSnapModal/index.tsx
+++ b/apps/web/src/components/library/GuestSnapModal/index.tsx
@@ -48,13 +48,19 @@ const GuestSnapModal = ({ id, isOpen, onClose }: Props) => {
     setStep('LIST');
   };
 
-  const handleDownload = () => {
+  const handleDownload = async () => {
+    const imageUrl = images[selectedIndex!];
+    const response = await fetch(imageUrl, { mode: 'cors' });
+    const blob = await response.blob();
+
+    const blobUrl = URL.createObjectURL(blob);
     const link = document.createElement('a');
-    link.href = images[selectedIndex!];
+    link.href = blobUrl;
     link.download = `guest_snap_${selectedIndex! + 1}.png`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
+    URL.revokeObjectURL(blobUrl);
   };
 
   const handlePrev = () => {

--- a/apps/web/src/components/library/InvitationItem/index.tsx
+++ b/apps/web/src/components/library/InvitationItem/index.tsx
@@ -51,8 +51,9 @@ const InvitationItem = ({ id, title, templateId, picture, updateAt }: Props) => 
   };
 
   const handleMailClick = () => {
+    if (!data) return;
     overlay.open(({ isOpen, close }) => (
-      <PreviewModal id={id} isOpen={isOpen} onClose={close} />
+      <PreviewModal data={data} isOpen={isOpen} onClose={close} />
     ));
   };
 

--- a/apps/web/src/components/library/InvitationItem/index.tsx
+++ b/apps/web/src/components/library/InvitationItem/index.tsx
@@ -63,7 +63,7 @@ const InvitationItem = ({ id, title, templateId, picture, updateAt }: Props) => 
 
   return (
     <StyledInvitationItem>
-      <InvitationImage imageUrl={picture} />
+      <InvitationImage imageUrl={picture || `/templateFull${templateId}.png`} />
       <InvitationInfo>
         <Row width="100%" justifyContent="space-between" alignItems="center">
           <Column gap={4} alignItems="flex-start">

--- a/apps/web/src/components/library/InvitationList/index.tsx
+++ b/apps/web/src/components/library/InvitationList/index.tsx
@@ -72,7 +72,7 @@ const EmptyState = styled.div`
 `;
 
 const ScrollableList = styled.div`
-  ${flex({ alignItems: 'center' })}
+  ${flex({ alignItems: 'flex-start' })}
   flex-wrap: wrap;
   gap: 20px 24px;
   overflow-y: auto;

--- a/apps/web/src/components/library/PreviewModal/Account/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/Account/index.tsx
@@ -4,16 +4,14 @@ import { Column } from '@merried/ui';
 import { flex } from '@merried/utils';
 import styled from 'styled-components';
 import AccountItem from './AccountItem';
-import { useCardsQuery } from '@/services/form/queries';
 import type { Account, CustomFontType } from '@/types/form/client';
+import { PutCardReq } from '@/types/form/remote';
 
 interface Props {
-  id: string;
+  data: PutCardReq;
 }
 
-const Account = ({ id }: Props) => {
-  const { data } = useCardsQuery(id);
-
+const Account = ({ data }: Props) => {
   if (!data || !data?.accountInfo) return null;
 
   const invitationFont = data.invitationSetting.font;

--- a/apps/web/src/components/library/PreviewModal/CoupleInfo/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/CoupleInfo/index.tsx
@@ -1,15 +1,13 @@
 import { flex } from '@merried/utils';
 import styled from 'styled-components';
 import CoupleInfoItem from './CoupleInfoItem';
-import { useCardsQuery } from '@/services/form/queries';
+import { PutCardReq } from '@/types/form/remote';
 
 interface Props {
-  id: string;
+  data: PutCardReq;
 }
 
-const CoupleInfo = ({ id }: Props) => {
-  const { data } = useCardsQuery(id);
-
+const CoupleInfo = ({ data }: Props) => {
   if (!data || !data?.groomProfile || !data?.brideProfile) return null;
 
   const groom = data.groomProfile;

--- a/apps/web/src/components/library/PreviewModal/Direction/BrandButton/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/Direction/BrandButton/index.tsx
@@ -2,17 +2,39 @@ import { color } from '@merried/design-system';
 import { Text } from '@merried/ui';
 import { flex } from '@merried/utils';
 import Image from 'next/image';
+import { useCallback } from 'react';
 import styled from 'styled-components';
 
 interface BrandButtonProps {
-  onClick: () => void;
   src: string;
-  name: string;
+  name: '네이버지도' | '카카오맵';
+  address: string;
 }
 
-const BrandButton = ({ onClick, src, name }: BrandButtonProps) => {
+const BrandButton = ({ src, name, address }: BrandButtonProps) => {
+  const handleClick = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    const geocoder = new window.kakao.maps.services.Geocoder();
+
+    geocoder.addressSearch(address, (result, status) => {
+      if (status === window.kakao.maps.services.Status.OK && result.length > 0) {
+        const { y, x } = result[0];
+
+        if (name === '카카오맵') {
+          const url = `https://map.kakao.com/link/to/${encodeURIComponent(address)},${y},${x}`;
+          window.open(url, '_blank');
+        } else if (name === '네이버지도') {
+          const url = `https://map.naver.com/p/search/${encodeURIComponent(address)}`;
+          window.open(url, '_blank');
+        }
+      } else {
+        alert('주소를 찾을 수 없습니다.');
+      }
+    });
+  }, [address, name]);
+
   return (
-    <StyledBrandButton onClick={onClick}>
+    <StyledBrandButton onClick={handleClick}>
       <Image width={20} height={20} src={src} alt="icon" />
       <Text fontType="Button2" color={color.G900}>
         {name}

--- a/apps/web/src/components/library/PreviewModal/Direction/BrandButton/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/Direction/BrandButton/index.tsx
@@ -1,3 +1,4 @@
+import { showToast } from '@/utils';
 import { color } from '@merried/design-system';
 import { Text } from '@merried/ui';
 import { flex } from '@merried/utils';
@@ -28,7 +29,7 @@ const BrandButton = ({ src, name, address }: BrandButtonProps) => {
           window.open(url, '_blank');
         }
       } else {
-        alert('주소를 찾을 수 없습니다.');
+        showToast('주소를 찾을 수 없습니다', 'ERROR');
       }
     });
   }, [address, name]);

--- a/apps/web/src/components/library/PreviewModal/Direction/KakaoMap/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/Direction/KakaoMap/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from 'next/image';
 import React, { useEffect, useState } from 'react';
 import { CustomOverlayMap, Map } from 'react-kakao-maps-sdk';

--- a/apps/web/src/components/library/PreviewModal/Direction/Transportation/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/Direction/Transportation/index.tsx
@@ -1,4 +1,3 @@
-import { TRANSPORT_MAP } from '@/constants/form/constants';
 import { color } from '@merried/design-system';
 import { Text } from '@merried/ui';
 import { flex } from '@merried/utils';
@@ -14,7 +13,7 @@ const Transportation = ({ type, method }: TransportationProps) => {
     <div>
       <StyledTransportation>
         <Text fontType="H4" color={color.G900}>
-          {TRANSPORT_MAP[type]}
+          {type}
         </Text>
         <Text fontType="P2" color={color.G80} whiteSpace="pre-wrap">
           {method}

--- a/apps/web/src/components/library/PreviewModal/Direction/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/Direction/index.tsx
@@ -63,13 +63,12 @@ const Direction = ({ data }: Props) => {
         </CustomText>
         <KakaoMap address={mainAddress} />
       </Column>
-
       <Row width="100%" alignItems="center" justifyContent="space-between">
-        <Column gap={4} alignItems="flex-start">
-          <Text fontType="P2" color={color.G80}>
+        <Column width="60%" gap={4} alignItems="flex-start">
+          <Text width="100%" whiteSpace="normal" fontType="P2" color={color.G80}>
             {mainAddress}
           </Text>
-          <Text fontType="H4" color={color.G900}>
+          <Text fontType="H4" whiteSpace="normal" color={color.G900}>
             {buildingName}
           </Text>
         </Column>
@@ -79,7 +78,6 @@ const Direction = ({ data }: Props) => {
           </Text>
         </ActionButton>
       </Row>
-
       <Row width="100%" alignItems="center" gap={19}>
         {BRAND.map(({ src, name }) => (
           <BrandButton
@@ -114,4 +112,31 @@ const Line = styled.div`
   width: 100%;
   height: 1px;
   background-color: ${color.G40};
+`;
+
+const RowContainer = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+
+  @media (max-width: 500px) {
+    flex-direction: column;
+    align-items: stretch;
+  }
+`;
+
+const TextContainer = styled.div`
+  flex: 1;
+  min-width: 0;
+  word-break: break-word;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  & span {
+    white-space: normal;
+    word-break: break-word;
+  }
 `;

--- a/apps/web/src/components/library/PreviewModal/Direction/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/Direction/index.tsx
@@ -82,7 +82,12 @@ const Direction = ({ data }: Props) => {
 
       <Row width="100%" alignItems="center" gap={19}>
         {BRAND.map(({ src, name }) => (
-          <BrandButton key={name} src={src} name={name} onClick={() => {}} />
+          <BrandButton
+            key={name}
+            src={src}
+            name={name as '네이버지도' | '카카오맵'}
+            address={mainAddress}
+          />
         ))}
       </Row>
 

--- a/apps/web/src/components/library/PreviewModal/Direction/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/Direction/index.tsx
@@ -7,16 +7,14 @@ import { ActionButton, Column, Row, Text } from '@merried/ui';
 import BrandButton from './BrandButton';
 import Transportation from './Transportation';
 import { TRANSPORT_TYPES, BRAND } from '@/constants/form/constants';
-import { useCardsQuery } from '@/services/form/queries';
 import { CustomFontType } from '@/types/form/client';
+import { PutCardReq } from '@/types/form/remote';
 
 interface Props {
-  id: string;
+  data: PutCardReq;
 }
 
-const Direction = ({ id }: Props) => {
-  const { data } = useCardsQuery(id);
-
+const Direction = ({ data }: Props) => {
   if (!data || !data.locationGuide) return null;
 
   const { address, isSubway, subwayDetail, isBus, busDetail, hasParking, parkingDetail } =

--- a/apps/web/src/components/library/PreviewModal/Greeting/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/Greeting/index.tsx
@@ -1,16 +1,14 @@
 import { CustomText } from '@/components/common';
-import { useCardsQuery } from '@/services/form/queries';
 import { CustomFontType } from '@/types/form/client';
+import { PutCardReq } from '@/types/form/remote';
 import { color } from '@merried/design-system';
 import { Column } from '@merried/ui';
 
 interface Props {
-  id: string;
+  data: PutCardReq;
 }
 
-const Greeting = ({ id }: Props) => {
-  const { data } = useCardsQuery(id);
-
+const Greeting = ({ data }: Props) => {
   if (!data || !data?.invitationMessage) return null;
 
   const title = data.invitationMessage.title;

--- a/apps/web/src/components/library/PreviewModal/GuestBook/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/GuestBook/index.tsx
@@ -5,16 +5,14 @@ import styled from 'styled-components';
 import WriteGuestBook from './WriteGuestBook';
 import { Column } from '@merried/ui';
 import GuestBookList from './GuestBookList';
-import { useCardsQuery } from '@/services/form/queries';
 import { CustomFontType } from '@/types/form/client';
+import { PutCardReq } from '@/types/form/remote';
 
 interface Props {
-  id: string;
+  data: PutCardReq;
 }
 
-const GuestBook = ({ id }: Props) => {
-  const { data } = useCardsQuery(id);
-
+const GuestBook = ({ data }: Props) => {
   if (!data || !data?.guestBook) return null;
 
   const guestBook = data.guestBook;

--- a/apps/web/src/components/library/PreviewModal/GuestSnapShot/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/GuestSnapShot/index.tsx
@@ -4,16 +4,14 @@ import { Column } from '@merried/ui';
 import { flex } from '@merried/utils';
 import styled from 'styled-components';
 import GuestSnapShotContent from './GuestSnapShotContent';
-import { useCardsQuery } from '@/services/form/queries';
 import { CustomFontType } from '@/types/form/client';
+import { PutCardReq } from '@/types/form/remote';
 
 interface Props {
-  id: string;
+  data: PutCardReq;
 }
 
-const GuestSnapShot = ({ id }: Props) => {
-  const { data } = useCardsQuery(id);
-
+const GuestSnapShot = ({ data }: Props) => {
   if (!data || !data?.guestSnapshots) return null;
 
   const guestSnapshots = data.guestSnapshots;

--- a/apps/web/src/components/library/PreviewModal/Guide/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/Guide/index.tsx
@@ -2,16 +2,14 @@ import CustomText from '@/components/common/CustomText/CustomText';
 import { color } from '@merried/design-system';
 import { flex } from '@merried/utils';
 import styled from 'styled-components';
-import { useCardsQuery } from '@/services/form/queries';
 import { CustomFontType } from '@/types/form/client';
+import { PutCardReq } from '@/types/form/remote';
 
 interface Props {
-  id: string;
+  data: PutCardReq;
 }
 
-const Guide = ({ id }: Props) => {
-  const { data } = useCardsQuery(id);
-
+const Guide = ({ data }: Props) => {
   if (!data || !data?.guestNotice) return null;
 
   const notice = data.guestNotice;

--- a/apps/web/src/components/library/PreviewModal/MainScreen/TextOverlay/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/MainScreen/TextOverlay/index.tsx
@@ -26,5 +26,5 @@ const StyledText = styled.div<{ $id: string; $font: string; $color: string }>`
   position: absolute;
   width: 100%;
   text-align: center;
-  white-space: pre-line;
+  white-space: pre;
 `;

--- a/apps/web/src/components/library/PreviewModal/MainScreen/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/MainScreen/index.tsx
@@ -3,21 +3,19 @@ import { IconShortArrow } from '@merried/icon';
 import { flex } from '@merried/utils';
 import TextOverlay from './TextOverlay';
 import SubTextOverlay from './SubTextOverlay';
-import { useCeremonyInfoValueStore } from '@/store/form/ceremonyInfo';
 import { color } from '@merried/design-system';
-import { useCardsQuery } from '@/services/form/queries';
+import { PutCardReq } from '@/types/form/remote';
 
 interface Props {
-  id: string;
+  data: PutCardReq;
   onScrollClick: () => void;
 }
 
-const MainScreen = ({ id, onScrollClick }: Props) => {
-  const { data } = useCardsQuery(id);
-
+const MainScreen = ({ data, onScrollClick }: Props) => {
   if (!data) return null;
 
   const { picture, letteringColor, lettering, font } = data.mainPageSetting;
+  const templateId = data.templateId;
 
   const groom = data.groomProfile;
   const bride = data.brideProfile;
@@ -26,14 +24,19 @@ const MainScreen = ({ id, onScrollClick }: Props) => {
 
   return (
     <StyledMainScreen $imageUrl={picture}>
-      {id === '7' && <SvgOverlay src="/template7Backgroud.svg" alt="overlay" />}
-      <TextOverlay id={id} text={lettering[0]} color={letteringColor} font={font} />
+      {templateId === '7' && <SvgOverlay src="/template7Backgroud.svg" alt="overlay" />}
+      <TextOverlay
+        id={templateId}
+        text={lettering[0]}
+        color={letteringColor}
+        font={font}
+      />
       <SubTextOverlay
-        id={id}
+        id={templateId}
         groomName={groom?.name || 'OOO'}
         brideName={bride?.name || 'OOO'}
         dateStr={`${calenderDate}`}
-        color={id === '5' || id === '6' ? letteringColor : color.G0}
+        color={templateId === '5' || templateId === '6' ? letteringColor : color.G0}
       />
       <ScrollTriggerButton onClick={onScrollClick}>
         <IconShortArrow width={16} height={16} />

--- a/apps/web/src/components/library/PreviewModal/MainScreen/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/MainScreen/index.tsx
@@ -23,7 +23,12 @@ const MainScreen = ({ data, onScrollClick }: Props) => {
   const calenderDate = data.weddingInfo?.date;
 
   return (
-    <StyledMainScreen $imageUrl={picture || `/templateFull${templateId}.png`}>
+    <StyledMainScreen>
+      <BackgroundImage
+        src={picture || `/templateFull${templateId}.png`}
+        $isShrinked={templateId === '5'}
+        alt="main background"
+      />
       {templateId === '7' && <SvgOverlay src="/template7Backgroud.svg" alt="overlay" />}
       <TextOverlay
         id={templateId}
@@ -47,15 +52,25 @@ const MainScreen = ({ data, onScrollClick }: Props) => {
 
 export default MainScreen;
 
-const StyledMainScreen = styled.div<{ $imageUrl: string }>`
+const StyledMainScreen = styled.div`
   position: relative;
   width: 100%;
   height: 812px;
-  background-image: ${({ $imageUrl }) => `url(${$imageUrl})`};
-  background-size: cover;
-  background-position: center;
+  overflow: hidden;
   ${flex({ flexDirection: 'column', justifyContent: 'flex-end', alignItems: 'center' })}
   flex-shrink: 0;
+  background: ${color.G0};
+`;
+
+const BackgroundImage = styled.img<{ $isShrinked: boolean }>`
+  position: absolute;
+  top: ${({ $isShrinked }) => ($isShrinked ? '10px' : '0')};
+  left: 50%;
+  transform: translateX(-50%);
+  width: ${({ $isShrinked }) => ($isShrinked ? '94%' : '100%')};
+  height: ${({ $isShrinked }) => ($isShrinked ? '60%' : '100%')};
+  object-fit: cover;
+  z-index: 0;
 `;
 
 const ScrollTriggerButton = styled.div`

--- a/apps/web/src/components/library/PreviewModal/MainScreen/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/MainScreen/index.tsx
@@ -23,7 +23,7 @@ const MainScreen = ({ data, onScrollClick }: Props) => {
   const calenderDate = data.weddingInfo?.date;
 
   return (
-    <StyledMainScreen $imageUrl={picture}>
+    <StyledMainScreen $imageUrl={picture || `/templateFull${templateId}.png`}>
       {templateId === '7' && <SvgOverlay src="/template7Backgroud.svg" alt="overlay" />}
       <TextOverlay
         id={templateId}

--- a/apps/web/src/components/library/PreviewModal/UrlShareStyle/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/UrlShareStyle/index.tsx
@@ -1,14 +1,12 @@
 import { color } from '@merried/design-system';
 import { Button, Column, Text } from '@merried/ui';
-import { useCardsQuery } from '@/services/form/queries';
+import { PutCardReq } from '@/types/form/remote';
 
 interface Props {
-  id: string;
+  data: PutCardReq;
 }
 
-const UrlShareStyle = ({ id }: Props) => {
-  const { data } = useCardsQuery(id);
-
+const UrlShareStyle = ({ data }: Props) => {
   if (!data || !data?.shareUrlStyle) return null;
 
   const pointColor = data.invitationSetting.pointColor;

--- a/apps/web/src/components/library/PreviewModal/WeddingAlbum/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/WeddingAlbum/index.tsx
@@ -5,16 +5,14 @@ import { IconLongArrow } from '@merried/icon';
 import { Row, Text } from '@merried/ui';
 import { flex } from '@merried/utils';
 import styled from 'styled-components';
-import { useCardsQuery } from '@/services/form/queries';
 import { CustomFontType } from '@/types/form/client';
+import { PutCardReq } from '@/types/form/remote';
 
 interface Props {
-  id: string;
+  data: PutCardReq;
 }
 
-const WeddingAlbum = ({ id }: Props) => {
-  const { data } = useCardsQuery(id);
-
+const WeddingAlbum = ({ data }: Props) => {
   if (!data || !data?.photoGallery) return null;
 
   const { photoGallery, invitationSetting } = data;

--- a/apps/web/src/components/library/PreviewModal/WeddingCalender/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/WeddingCalender/index.tsx
@@ -5,17 +5,15 @@ import { IconOval } from '@merried/icon';
 import styled from 'styled-components';
 import { flex } from '@merried/utils';
 import { Column } from '@merried/ui';
-import { useCardsQuery } from '@/services/form/queries';
+import { PutCardReq } from '@/types/form/remote';
 
 dayjs.locale('ko');
 
 interface Props {
-  id: string;
+  data: PutCardReq;
 }
 
-const WeddingCalender = ({ id }: Props) => {
-  const { data } = useCardsQuery(id);
-
+const WeddingCalender = ({ data }: Props) => {
   if (!data || !data?.weddingInfo) return null;
 
   const invitationSetting = data.invitationSetting;

--- a/apps/web/src/components/library/PreviewModal/WeddingIntro/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/WeddingIntro/index.tsx
@@ -1,17 +1,15 @@
 import CustomText from '@/components/common/CustomText/CustomText';
-import { useCardsQuery } from '@/services/form/queries';
 import { CustomFontType } from '@/types/form/client';
+import { PutCardReq } from '@/types/form/remote';
 import { color } from '@merried/design-system';
 import { flex } from '@merried/utils';
 import styled from 'styled-components';
 
 interface Props {
-  id: string;
+  data: PutCardReq;
 }
 
-const WeddingIntro = ({ id }: Props) => {
-  const { data } = useCardsQuery(id);
-
+const WeddingIntro = ({ data }: Props) => {
   if (!data || !data?.videoGallery) return null;
 
   const videoGallery = data.videoGallery;

--- a/apps/web/src/components/library/PreviewModal/index.tsx
+++ b/apps/web/src/components/library/PreviewModal/index.tsx
@@ -16,11 +16,11 @@ import GuestBook from './GuestBook';
 import GuestSnapShot from './GuestSnapShot';
 import UrlShareStyle from './UrlShareStyle';
 import MainScreen from './MainScreen';
-import { useCardsQuery } from '@/services/form/queries';
 import { IconDelete } from '@merried/icon';
+import { PutCardReq } from '@/types/form/remote';
 
 interface ComponentsProps {
-  id: string;
+  data: PutCardReq;
 }
 
 const PREVIEW_COMPONENTS: Record<string, React.FC<ComponentsProps>> = {
@@ -38,16 +38,14 @@ const PREVIEW_COMPONENTS: Record<string, React.FC<ComponentsProps>> = {
 };
 
 interface Props {
-  id: string;
+  data: PutCardReq;
   isOpen: boolean;
   onClose: () => void;
 }
 
-const PreviewModal = ({ id, isOpen, onClose }: Props) => {
+const PreviewModal = ({ data, isOpen, onClose }: Props) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
-
-  const { data } = useCardsQuery(id);
 
   const scrollToContent = () => {
     if (scrollRef.current && contentRef.current) {
@@ -73,14 +71,14 @@ const PreviewModal = ({ id, isOpen, onClose }: Props) => {
       />
       <StyledPreview>
         <ScrollableArea ref={scrollRef}>
-          <MainScreen id={id} onScrollClick={scrollToContent} />
+          <MainScreen data={data} onScrollClick={scrollToContent} />
 
           <ContentSection ref={contentRef}>
             {data?.componentOrders
               ?.sort((a, b) => a.order - b.order)
               .map(({ componentType }) => {
                 const Component = PREVIEW_COMPONENTS[componentType];
-                return Component ? <Component key={componentType} id={id} /> : null;
+                return Component ? <Component key={componentType} data={data} /> : null;
               })}
             <Text fontType="P4" color={color.G80}>
               COPYRIGHT Kangwon Park. All rights reserved.

--- a/apps/web/src/components/template/TemplateItem/index.tsx
+++ b/apps/web/src/components/template/TemplateItem/index.tsx
@@ -1,7 +1,10 @@
+import PreviewModal from '@/components/library/PreviewModal';
 import { ROUTES } from '@/constants/common/constant';
+import { getTemplateById } from '@/constants/form/constants';
 import { color } from '@merried/design-system';
 import { DesktopButton, Text } from '@merried/ui';
 import { flex } from '@merried/utils';
+import { useOverlay } from '@toss/use-overlay';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { styled } from 'styled-components';
@@ -13,12 +16,19 @@ interface Props {
 }
 
 const TemplateItem = ({ id, path, title }: Props) => {
+  const overlay = useOverlay();
   const router = useRouter();
 
   const handleMoveFormPage = () => {
     router.push(`${ROUTES.FORM}/${id}`);
   };
 
+  const handlePreviewClick = () => {
+    const templateData = getTemplateById(String(id));
+    overlay.open(({ isOpen, close }) => (
+      <PreviewModal data={templateData} isOpen={isOpen} onClose={close} />
+    ));
+  };
   return (
     <StyledTemplateItem>
       <ImageWrapper>
@@ -35,9 +45,11 @@ const TemplateItem = ({ id, path, title }: Props) => {
           <Text fontType="P3" color={color.G0}>
             또는
           </Text>
-          <Text fontType="P3" color={color.G0} underline={true}>
-            청첩장 미리보기
-          </Text>
+          <div style={{ cursor: 'pointer' }} onClick={handlePreviewClick}>
+            <Text fontType="P3" color={color.G0} underline={true}>
+              청첩장 미리보기
+            </Text>
+          </div>
         </Overlay>
       </ImageWrapper>
       {title}
@@ -56,7 +68,6 @@ const ImageWrapper = styled.div`
   position: relative;
   width: 284px;
   height: 615px;
-  cursor: pointer;
 `;
 
 const Overlay = styled.div`

--- a/apps/web/src/constants/form/constants.ts
+++ b/apps/web/src/constants/form/constants.ts
@@ -1,3 +1,4 @@
+import { PutCardReq } from '@/types/form/remote';
 import { color } from '@merried/design-system';
 
 export const LETTERING_COLORS = [
@@ -63,3 +64,183 @@ export const TRANSPORT_MAP: Record<string, string> = {
 };
 
 export type TransportType = (typeof TRANSPORT_TYPES)[number];
+
+const templateBase: Omit<PutCardReq, 'templateId' | 'mainPageSetting'> = {
+  id: 'dsafsdafsa',
+  title: '',
+  invitationSetting: {
+    pointColor: '#FFDF3E',
+    font: 'Ownglyph Kundo',
+  },
+  invitationMessage: {
+    title: '초대글귀',
+    content:
+      '서로의 반쪽이 되어 걸어갈 길 위에서 저희 두 사람이 인생의 새로운 첫걸음을 내딛습니다. 소중한 걸음 해주시어 축복해 주시면 감사하겠습니다.',
+  },
+  groomProfile: {
+    name: '견우',
+    fatherName: '여상',
+    isFatherDeceased: false,
+    motherName: '도연',
+    isMotherDeceased: false,
+  },
+  brideProfile: {
+    name: '직녀',
+    fatherName: '옥황',
+    isFatherDeceased: false,
+    motherName: '서왕모',
+    isMotherDeceased: false,
+  },
+  weddingInfo: {
+    date: '2025-08-21T15:00:00',
+    weddingHallName: '오작교',
+    isCalendarVisible: true,
+  },
+  photoGallery: {
+    title: '갤러리',
+    urls: [
+      'https://married-get.s3.ap-northeast-2.amazonaws.com/56e22e646fef4285a4b0e1a8b4ab8b95/354cbcaa-6458-4a3d-a529-b0f1b72f4b82_images.jpg',
+      'https://married-get.s3.ap-northeast-2.amazonaws.com/56e22e646fef4285a4b0e1a8b4ab8b95/6a03e386-c7c4-43c8-a038-057beb09c449_다운로드.jpg',
+      'https://married-get.s3.ap-northeast-2.amazonaws.com/56e22e646fef4285a4b0e1a8b4ab8b95/d447a47f-a5d8-40fb-a937-01b5b47ff8c6_칠석-여름-별자리_06.jpg',
+      'https://married-get.s3.ap-northeast-2.amazonaws.com/56e22e646fef4285a4b0e1a8b4ab8b95/80885d05-9fb1-4726-9169-3a042a14c174_칠석-여름-별자리_01.jpg',
+    ],
+  },
+  videoGallery: {
+    title: '견우와 직녀',
+    url: 'https://www.youtube.com/watch?v=c5AZXAYH77w',
+  },
+  locationGuide: {
+    address: '강원특별자치도 고성군 간성읍 수성로22번길 13-3/오작교',
+    isSubway: true,
+    subwayDetail: '가까운 지하철이 없습니다. 버스로 방문을 부탁 드립니다.',
+    isBus: true,
+    busDetail: '까치가 직접 다리를 만들어서 안내해줍니다.',
+    hasParking: true,
+    parkingDetail: '차를 가지고 올 수 없습니다.',
+  },
+  accountInfo: {
+    title: '마음 전하실 곳',
+    content:
+      '부득이한 사정으로 식장에 오시지 못하지만 마음을 직접적으로 전하고 싶으시다면 이용할 수 있습니다.',
+    groom: {
+      bankName: '신한',
+      accountNumber: '123123123123',
+      accountHolderName: '견우',
+    },
+    bride: {
+      bankName: '한국',
+      accountNumber: '123123123123',
+      accountHolderName: '직녀',
+    },
+    groomFather: {
+      bankName: '',
+      accountNumber: '',
+      accountHolderName: '',
+    },
+    groomMother: {
+      bankName: '',
+      accountNumber: '',
+      accountHolderName: '',
+    },
+    brideFather: {
+      bankName: '우리',
+      accountNumber: '123123123123',
+      accountHolderName: '옥활',
+    },
+    brideMother: {
+      bankName: '',
+      accountNumber: '',
+      accountHolderName: '',
+    },
+  },
+  guestNotice: {
+    title: '안내사항',
+    content:
+      '무게가 너무 무거우면 까치가 못 버틸 수도 있습니다. 다들 구름빵을 드시고 와주시길 바랍니다.',
+  },
+  guestBook: {
+    title: '방명록',
+    masterPassword: '1234',
+  },
+  guestSnapshots: {
+    title: '게스트 스냅',
+    masterPassword: '1234',
+  },
+  shareUrlStyle: {
+    thumbnailUrl: '아무URL',
+    title: '',
+    content: '',
+  },
+  componentOrders: [
+    { componentType: 'INVITATION_MESSAGE', order: 0 },
+    { componentType: 'GROOM_BRIDE_PROFILE', order: 1 },
+    { componentType: 'WEDDING_DATE', order: 2 },
+    { componentType: 'PHOTO_GALLERY', order: 3 },
+    { componentType: 'VIDEO_GALLERY', order: 4 },
+    { componentType: 'LOCATION_GUIDE', order: 5 },
+    { componentType: 'ACCOUNT_INFO', order: 6 },
+    { componentType: 'GUEST_NOTICE', order: 7 },
+    { componentType: 'GUEST_BOOK', order: 8 },
+    { componentType: 'GUEST_SNAPSHOTS', order: 9 },
+    { componentType: 'SHARE_URL_STYLE', order: 10 },
+  ],
+};
+
+const templateMainPageSettings: Record<string, PutCardReq['mainPageSetting']> = {
+  '1': {
+    picture: '',
+    font: 'BBB0003',
+    lettering: ['THE START OF \nOUR FORERVER'],
+    letteringColor: '#FFDF3E',
+  },
+  '2': {
+    picture: '',
+    font: 'Ownglyph Baek Subin',
+    lettering: ['By your side'],
+    letteringColor: '#fffffe',
+  },
+  '3': {
+    picture: '',
+    font: 'White Angelica',
+    lettering: ['Dear My \nSoulmate'],
+    letteringColor: '#fffffe',
+  },
+  '4': {
+    picture: '',
+    font: 'Diphylleia',
+    lettering: ['끝나지 않을\n행복의 시작'],
+    letteringColor: '#fffffe',
+  },
+  '5': {
+    picture: '',
+    font: 'White Angelica',
+    lettering: ['Endless Love'],
+    letteringColor: '#65E052',
+  },
+  '6': {
+    picture: '',
+    font: 'White Angelica',
+    lettering: ['We Ar\nGetting Married'],
+    letteringColor: '#FF0808',
+  },
+  '7': {
+    picture: '',
+    font: 'KoreanCNMM',
+    lettering: ['Our\nLovely\nDays'],
+    letteringColor: '#fefa66',
+  },
+  '8': {
+    picture: '',
+    font: 'Ownglyph Kundo',
+    lettering: ['Wedding'],
+    letteringColor: '#fffffe',
+  },
+};
+
+export const getTemplateById = (id: string): PutCardReq => {
+  return {
+    ...templateBase,
+    templateId: id,
+    mainPageSetting: templateMainPageSettings[id],
+  };
+};

--- a/apps/web/src/constants/form/constants.ts
+++ b/apps/web/src/constants/form/constants.ts
@@ -51,7 +51,7 @@ export const GENDER_MAP = {
 } as const;
 
 export const BRAND = [
-  { src: '/IconTMap.svg', name: '티맵' },
+  { src: '/IconNaver.svg', name: '네이버지도' },
   { src: '/IconKakaoMap.svg', name: '카카오맵' },
 ];
 

--- a/apps/web/src/services/auth/mutations.ts
+++ b/apps/web/src/services/auth/mutations.ts
@@ -3,6 +3,7 @@ import { deleteWithdraw, postLogin, postLogout } from './apis';
 import { Storage } from '@/apis/storage/storage';
 import { ROUTES, TOKEN } from '@/constants/common/constant';
 import { useRouter } from 'next/navigation';
+import { showToast } from '@/utils';
 
 export const useLoginMutation = () => {
   const router = useRouter();
@@ -13,11 +14,13 @@ export const useLoginMutation = () => {
       Storage.setItem(TOKEN.REFRESH, refreshToken);
       Storage.setItem('type', provider);
       router.replace(ROUTES.MAIN);
+      showToast('로그인에 성공했습니다.', 'SUCCESS');
     },
     onError: (error) => {
       Storage.clear();
       console.error('로그인 중 에러 발생:', error);
       router.replace(ROUTES.MAIN);
+      showToast('로그인에 실패했습니다.', 'ERROR');
     },
   });
 

--- a/apps/web/src/services/form/mutations.ts
+++ b/apps/web/src/services/form/mutations.ts
@@ -2,6 +2,7 @@ import { useRouter } from 'next/navigation';
 import { deleteCards, postCards, postGuestSnapshots, putCardsUpdate } from './apis';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { KEY, ROUTES } from '@/constants/common/constant';
+import { showToast } from '@/utils';
 
 export const useCreateCardMutation = () => {
   const router = useRouter();
@@ -9,11 +10,11 @@ export const useCreateCardMutation = () => {
   const { mutate: createCardMutate, ...restMutation } = useMutation({
     mutationFn: postCards,
     onSuccess: () => {
-      alert('카드가 성공적으로 생성되었습니다.');
+      showToast('청첩장이 생성되었습니다.', 'SUCCESS');
       router.push(ROUTES.LIBRARY);
     },
     onError: () => {
-      alert('카드 생성에 실패했습니다.');
+      showToast('청첩장이 생성되지 않았습니다.', 'ERROR');
     },
   });
 

--- a/apps/web/src/services/form/mutations.ts
+++ b/apps/web/src/services/form/mutations.ts
@@ -27,11 +27,11 @@ export const useDeleteCardMutation = () => {
   const { mutate: deleteCardMutate, ...restMutation } = useMutation({
     mutationFn: (id: string) => deleteCards(id),
     onSuccess: () => {
-      alert('카드가 성공적으로 삭제되었습니다.');
+      showToast('청첩장이 삭제되었습니다.', 'SUCCESS');
       queryClient.invalidateQueries({ queryKey: [KEY.CARDS_LIST] });
     },
     onError: () => {
-      alert('카드 삭제에 실패했습니다.');
+      showToast('청첩장이 삭제되지 않았습니다.', 'ERROR');
     },
   });
 
@@ -44,11 +44,11 @@ export const usePutCardMutation = () => {
   const { mutate: putCardMutate, ...restMutation } = useMutation({
     mutationFn: putCardsUpdate,
     onSuccess: () => {
-      alert('카드가 성공적으로 수정되었습니다.');
+      showToast('청첩장이 수정되었습니다.', 'SUCCESS');
       router.push(ROUTES.LIBRARY);
     },
     onError: () => {
-      alert('카드 수정에 실패했습니다.');
+      showToast('청첩장이 수정되지 않았습니다.', 'ERROR');
     },
   });
 

--- a/apps/web/src/services/form/mutations.ts
+++ b/apps/web/src/services/form/mutations.ts
@@ -3,6 +3,7 @@ import { deleteCards, postCards, postGuestSnapshots, putCardsUpdate } from './ap
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { KEY, ROUTES } from '@/constants/common/constant';
 import { showToast } from '@/utils';
+import { AxiosError } from 'axios';
 
 export const useCreateCardMutation = () => {
   const router = useRouter();
@@ -13,8 +14,14 @@ export const useCreateCardMutation = () => {
       showToast('청첩장이 생성되었습니다.', 'SUCCESS');
       router.push(ROUTES.LIBRARY);
     },
-    onError: () => {
-      showToast('청첩장이 생성되지 않았습니다.', 'ERROR');
+    onError: (error: AxiosError) => {
+      const statusCode = error.response?.status;
+
+      if (statusCode === 400) {
+        showToast('필수 정보를 입력해주세요.', 'ERROR');
+      } else {
+        showToast('청첩장이 생성되지 않았습니다.', 'ERROR');
+      }
     },
   });
 

--- a/apps/web/src/utils/index.ts
+++ b/apps/web/src/utils/index.ts
@@ -3,3 +3,4 @@ export { default as getLetteringFontsById } from './getLetteringFontsById';
 export { default as applyTextPositionStyle } from './applyTextPositionStyle';
 export { default as getWeddingPosition } from './getWeddingPosition';
 export { default as formatWeddingDate } from './formatWeddingDate';
+export * from './useToast';

--- a/apps/web/src/utils/useToast.ts
+++ b/apps/web/src/utils/useToast.ts
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+export type ToastType = 'SUCCESS' | 'ERROR';
+
+interface ToastState {
+  label: string;
+  type: ToastType;
+}
+
+let setToastGlobal: (toast: ToastState | null) => void;
+
+export const useToastController = () => {
+  const [toast, _setToast] = useState<ToastState | null>(null);
+
+  setToastGlobal = _setToast;
+
+  return toast;
+};
+
+export const showToast = (label: string, type: ToastType) => {
+  if (setToastGlobal) {
+    setToastGlobal({ label, type });
+    setTimeout(() => setToastGlobal(null), 3000);
+  } else {
+    console.warn('ToastProvider가 마운트되어 있지 않음');
+  }
+};


### PR DESCRIPTION
## 📄 Summary

> 청접장 더미 데이터 미리보기를 추가했습니다.

<br>

## 🔨 Tasks

- 더미 데이터 미리보기 추가

<br>

## 🙋🏻 More


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 템플릿 미리보기 기능이 추가되어, 템플릿 목록에서 미리보기를 클릭하면 상세 미리보기 모달이 열립니다.
  * 네이버 지도 버튼이 추가되어 위치 안내에서 네이버 지도와 카카오맵을 지원합니다.
  * 전역 토스트 알림 기능이 도입되어 성공 및 오류 메시지를 시각적으로 확인할 수 있습니다.

* **기능 개선**
  * 미리보기 및 관련 컴포넌트들이 기존의 id 기반 데이터 조회 방식에서 데이터 객체 직접 전달 방식으로 변경되어, 더 빠르고 일관된 미리보기가 가능합니다.
  * 지도 안내 버튼 클릭 시 주소를 기반으로 지도 앱이 새 탭에서 열리며, 주소를 찾을 수 없을 경우 안내 메시지가 표시됩니다.
  * 썸네일 그룹이 선택한 이미지를 중심으로 표시되어 더 편리하게 이미지 탐색이 가능합니다.
  * 텍스트 및 레이아웃 스타일이 개선되어 가독성이 향상되었습니다.
  * 로그인 및 카드 관련 작업 시 기존 alert 대신 토스트 알림으로 사용자 피드백이 제공됩니다.
  * 배경 이미지가 CSS 배경에서 이미지 태그로 변경되어, 템플릿별로 더 유연한 배경 적용이 가능합니다.

* **버그 수정**
  * 유효하지 않은 데이터로 인해 오버레이가 잘못 열리는 현상이 방지되었습니다.
  * 썸네일 클릭 시 올바른 이미지가 선택되도록 동작이 개선되었습니다.

* **디자인/스타일**
  * 텍스트, 버튼, 레이아웃의 스타일이 일부 조정되어 시각적 일관성과 사용성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->